### PR TITLE
Some readability and clarity changes

### DIFF
--- a/opencv/highgui.nim
+++ b/opencv/highgui.nim
@@ -40,53 +40,53 @@
 #//M
 
 {.deadCodeElim: on.}
-when defined(windows): 
-  const 
-    highguidll* = "(lib|)opencv_highgui(249|231)d.dll"
-elif defined(macosx): 
-  const 
+when defined(windows):
+  const
+    highguidll* = "(lib|)opencv_highgui(249|231|)(d|).dll"
+elif defined(macosx):
+  const
     highguidll* = "libopencv_highgui.dylib"
-else: 
-  const 
+else:
+  const
     highguidll* = "libopencv_highgui.so"
 
 import core
 
 type
   TCapture*{.pure, final.} = object
-  
+
   TVideoWriter*{.pure, final.} = object
 
-#proc fontQt*(nameFont: cstring; pointSize: cint; color: TScalar; 
-#             weight: cint; style: cint; spacing: cint): TFont{.cdecl, 
+#proc fontQt*(nameFont: cstring; pointSize: cint; color: TScalar;
+#             weight: cint; style: cint; spacing: cint): TFont{.cdecl,
 #    importc: "cvFontQt", dynlib: highguidll.}
-#proc addText*(img: ptr TArr; text: cstring; org: TPoint; arg2: ptr TFont){.
+#proc addText*(img: ImgPtr; text: cstring; org: TPoint; arg2: ptr TFont){.
 #    cdecl, importc: "cvAddText", dynlib: highguidll.}
-proc displayOverlay*(name: cstring; text: cstring; delayms: cint){.cdecl, 
+proc displayOverlay*(name: cstring; text: cstring; delayms: cint){.cdecl,
     importc: "cvDisplayOverlay", dynlib: highguidll.}
-proc displayStatusBar*(name: cstring; text: cstring; delayms: cint){.cdecl, 
+proc displayStatusBar*(name: cstring; text: cstring; delayms: cint){.cdecl,
     importc: "cvDisplayStatusBar", dynlib: highguidll.}
-proc saveWindowParameters*(name: cstring){.cdecl, 
+proc saveWindowParameters*(name: cstring){.cdecl,
     importc: "cvSaveWindowParameters", dynlib: highguidll.}
-proc loadWindowParameters*(name: cstring){.cdecl, 
+proc loadWindowParameters*(name: cstring){.cdecl,
     importc: "cvLoadWindowParameters", dynlib: highguidll.}
 #int cvStartLoop(int (*pt2Func)(int argc, char *argv[]), int argc, char* argv[]);
 proc stopLoop*(){.cdecl, importc: "cvStopLoop", dynlib: highguidll.}
-type 
+type
   TButtonCallback* = proc (state: cint; userdata: pointer){.cdecl.}
-const 
+const
   PUSH_BUTTON* = 0
   CHECKBOX* = 1
   RADIOBOX* = 2
-proc createButton*(buttonName: cstring; onChange: TButtonCallback; 
-                   userdata: pointer; buttonType: cint; 
-                   initialButtonState: cint): cint{.cdecl, 
+proc createButton*(buttonName: cstring; onChange: TButtonCallback;
+                   userdata: pointer; buttonType: cint;
+                   initialButtonState: cint): cint{.cdecl,
     importc: "cvCreateButton", dynlib: highguidll.}
 #----------------------
-# this function is used to set some external parameters in case of X Window 
-proc initSystem*(argc: cint; argv: cstringArray): cint{.cdecl, 
+# this function is used to set some external parameters in case of X Window
+proc initSystem*(argc: cint; argv: cstringArray): cint{.cdecl,
     importc: "cvInitSystem", dynlib: highguidll.}
-proc startWindowThread*(): cint{.cdecl, importc: "cvStartWindowThread", 
+proc startWindowThread*(): cint{.cdecl, importc: "cvStartWindowThread",
                                  dynlib: highguidll.}
 # ---------  YV ---------
 const                       #These 3 flags are used by cvSet/GetWindowProperty
@@ -105,53 +105,53 @@ const                       #These 3 flags are used by cvSet/GetWindowProperty
   WINDOW_FULLSCREEN* = 1    #change the window to fullscreen
   WINDOW_FREERATIO* = 0x00000100 #the image expends as much as it can (no ratio constraint)
   WINDOW_KEEPRATIO* = 0x00000000 #the ration image is respected.
-# create window 
-proc namedWindow*(name: cstring; flags: cint): cint{.cdecl, 
+# create window
+proc namedWindow*(name: cstring; flags: cint): cint{.cdecl,
     importc: "cvNamedWindow", dynlib: highguidll.}
-# Set and Get Property of the window 
+# Set and Get Property of the window
 proc setWindowProperty*(name: cstring; propId: cint; propValue: cdouble){.
     cdecl, importc: "cvSetWindowProperty", dynlib: highguidll.}
-proc getWindowProperty*(name: cstring; propId: cint): cdouble{.cdecl, 
+proc getWindowProperty*(name: cstring; propId: cint): cdouble{.cdecl,
     importc: "cvGetWindowProperty", dynlib: highguidll.}
-# display image within window (highgui windows remember their content) 
-proc showImage*(name: cstring; image: ptr TArr){.cdecl, 
+# display image within window (highgui windows remember their content)
+proc showImage*(name: cstring; image: ImgPtr){.cdecl,
     importc: "cvShowImage", dynlib: highguidll.}
-# resize/move window 
-proc resizeWindow*(name: cstring; width: cint; height: cint){.cdecl, 
+# resize/move window
+proc resizeWindow*(name: cstring; width: cint; height: cint){.cdecl,
     importc: "cvResizeWindow", dynlib: highguidll.}
-proc moveWindow*(name: cstring; x: cint; y: cint){.cdecl, 
+proc moveWindow*(name: cstring; x: cint; y: cint){.cdecl,
     importc: "cvMoveWindow", dynlib: highguidll.}
-# destroy window and all the trackers associated with it 
-proc destroyWindow*(name: cstring){.cdecl, importc: "cvDestroyWindow", 
+# destroy window and all the trackers associated with it
+proc destroyWindow*(name: cstring){.cdecl, importc: "cvDestroyWindow",
                                     dynlib: highguidll.}
-proc destroyAllWindows*(){.cdecl, importc: "cvDestroyAllWindows", 
+proc destroyAllWindows*(){.cdecl, importc: "cvDestroyAllWindows",
                            dynlib: highguidll.}
-# get native window handle (HWND in case of Win32 and Widget in case of X Window) 
-proc getWindowHandle*(name: cstring): pointer{.cdecl, 
+# get native window handle (HWND in case of Win32 and Widget in case of X Window)
+proc getWindowHandle*(name: cstring): pointer{.cdecl,
     importc: "cvGetWindowHandle", dynlib: highguidll.}
-# get name of highgui window given its native handle 
-proc getWindowName*(windowHandle: pointer): cstring{.cdecl, 
+# get name of highgui window given its native handle
+proc getWindowName*(windowHandle: pointer): cstring{.cdecl,
     importc: "cvGetWindowName", dynlib: highguidll.}
 
-type 
+type
     TTrackbarCallback* = proc (pos: cint){.cdecl.}
-# create trackbar and display it on top of given window, set callback 
-proc createTrackbar*(trackbarName: cstring; windowName: cstring; 
-                     value: ptr cint; count: cint; 
-                     onChange: TTrackbarCallback): cint{.cdecl, 
+# create trackbar and display it on top of given window, set callback
+proc createTrackbar*(trackbarName: cstring; windowName: cstring;
+                     value: ptr cint; count: cint;
+                     onChange: TTrackbarCallback): cint{.cdecl,
     importc: "cvCreateTrackbar", dynlib: highguidll.}
-type 
+type
   TTrackbarCallback2* = proc (pos: cint; userdata: pointer){.cdecl.}
-proc createTrackbar2*(trackbarName: cstring; windowName: cstring; 
-                      value: ptr cint; count: cint; 
+proc createTrackbar2*(trackbarName: cstring; windowName: cstring;
+                      value: ptr cint; count: cint;
                       onChange: TTrackbarCallback2; userdata: pointer): cint{.
     cdecl, importc: "cvCreateTrackbar2", dynlib: highguidll.}
-# retrieve or set trackbar position 
+# retrieve or set trackbar position
 proc getTrackbarPos*(trackbarName: cstring; windowName: cstring): cint{.
     cdecl, importc: "cvGetTrackbarPos", dynlib: highguidll.}
 proc setTrackbarPos*(trackbarName: cstring; windowName: cstring; pos: cint){.
     cdecl, importc: "cvSetTrackbarPos", dynlib: highguidll.}
-const 
+const
   EVENT_MOUSEMOVE* = 0
   EVENT_LBUTTONDOWN* = 1
   EVENT_RBUTTONDOWN* = 2
@@ -162,26 +162,26 @@ const
   EVENT_LBUTTONDBLCLK* = 7
   EVENT_RBUTTONDBLCLK* = 8
   EVENT_MBUTTONDBLCLK* = 9
-const 
+const
   EVENT_FLAG_LBUTTON* = 1
   EVENT_FLAG_RBUTTON* = 2
   EVENT_FLAG_MBUTTON* = 4
   EVENT_FLAG_CTRLKEY* = 8
   EVENT_FLAG_SHIFTKEY* = 16
   EVENT_FLAG_ALTKEY* = 32
-type 
-  TCvMouseCallback* = proc (event: cint; x: cint; y: cint; flags: cint; 
+type
+  TCvMouseCallback* = proc (event: cint; x: cint; y: cint; flags: cint;
                             param: pointer){.cdecl.}
-# assign callback for mouse events 
-proc setMouseCallback*(windowName: cstring; onMouse: TCvMouseCallback; 
-                       param: pointer){.cdecl, importc: "cvSetMouseCallback", 
+# assign callback for mouse events
+proc setMouseCallback*(windowName: cstring; onMouse: TCvMouseCallback;
+                       param: pointer){.cdecl, importc: "cvSetMouseCallback",
     dynlib: highguidll.}
-const                       # 8bit, color or not 
+const                       # 8bit, color or not
                             #CV_LOAD_IMAGE_UNCHANGED  =-1,
-                            # 8bit, gray 
-  LOAD_IMAGE_GRAYSCALE* = 0 # ?, color 
-  LOAD_IMAGE_COLOR* = 1     # any depth, ? 
-  LOAD_IMAGE_ANYDEPTH* = 2  # ?, any color 
+                            # 8bit, gray
+  LOAD_IMAGE_GRAYSCALE* = 0 # ?, color
+  LOAD_IMAGE_COLOR* = 1     # any depth, ?
+  LOAD_IMAGE_ANYDEPTH* = 2  # ?, any color
   LOAD_IMAGE_ANYCOLOR* = 4
 # load image from file
 #  iscolor can be a combination of above flags where CV_LOAD_IMAGE_UNCHANGED
@@ -189,11 +189,11 @@ const                       # 8bit, color or not
 #  using CV_LOAD_IMAGE_ANYCOLOR alone is equivalent to CV_LOAD_IMAGE_UNCHANGED
 #  unless CV_LOAD_IMAGE_ANYDEPTH is specified images are converted to 8bit
 #
-proc loadImage*(filename: cstring; iscolor: cint): ptr TIplImage{.cdecl, 
+proc loadImage*(filename: cstring; iscolor: cint): ptr TIplImage{.cdecl,
     importc: "cvLoadImage", dynlib: highguidll.}
-#proc loadImageM*(filename: cstring; iscolor: cint): ptr TMat{.cdecl, 
+#proc loadImageM*(filename: cstring; iscolor: cint): MatPtr{.cdecl,
 #    importc: "cvLoadImageM", dynlib: highguidll.}
-const 
+const
   IMWRITE_JPEG_QUALITY* = 1
   IMWRITE_PNG_COMPRESSION* = 16
   IMWRITE_PNG_STRATEGY* = 17
@@ -204,45 +204,45 @@ const
   IMWRITE_PNG_STRATEGY_RLE* = 3
   IMWRITE_PNG_STRATEGY_FIXED* = 4
   IMWRITE_PXM_BINARY* = 32
-# save image to file 
-proc saveImage*(filename: cstring; image: ptr TArr; params: ptr cint): cint{.
+# save image to file
+proc saveImage*(filename: cstring; image: ImgPtr; params: ptr cint): cint{.
     cdecl, importc: "cvSaveImage", dynlib: highguidll.}
-# decode image stored in the buffer 
-#proc decodeImage*(buf: ptr TMat; iscolor: cint): ptr IplImage{.cdecl, 
+# decode image stored in the buffer
+#proc decodeImage*(buf: MatPtr; iscolor: cint): ptr IplImage{.cdecl,
 #    importc: "cvDecodeImage", dynlib: highguidll.}
-#proc decodeImageM*(buf: ptr TMat; iscolor: cint): ptr TMat{.cdecl, 
+#proc decodeImageM*(buf: MatPtr; iscolor: cint): MatPtr{.cdecl,
 #    importc: "cvDecodeImageM", dynlib: highguidll.}
-# encode image and store the result as a byte vector (single-row 8uC1 matrix) 
-#proc encodeImage*(ext: cstring; image: ptr TArr; params: ptr cint): ptr TMat{.
+# encode image and store the result as a byte vector (single-row 8uC1 matrix)
+#proc encodeImage*(ext: cstring; image: ImgPtr; params: ptr cint): MatPtr{.
 #    cdecl, importc: "cvEncodeImage", dynlib: highguidll.}
-const 
+const
   CVTIMG_FLIP* = 1
   CVTIMG_SWAP_RB* = 2
-# utility function: convert one image to another with optional vertical flip 
-proc convertImage*(src: ptr TArr; dst: ptr TArr; flags: cint){.cdecl, 
+# utility function: convert one image to another with optional vertical flip
+proc convertImage*(src: ImgPtr; dst: ImgPtr; flags: cint){.cdecl,
     importc: "cvConvertImage", dynlib: highguidll.}
-# wait for key event infinitely (delay<=0) or for "delay" milliseconds 
-proc waitKey*(delay: cint): cint{.cdecl, importc: "cvWaitKey", 
+# wait for key event infinitely (delay<=0) or for "delay" milliseconds
+proc waitKey*(delay: cint): cint{.cdecl, importc: "cvWaitKey",
                                   dynlib: highguidll.}
 # OpenGL support
-type 
+type
   TCvOpenGlDrawCallback* = proc (userdata: pointer){.cdecl.}
-proc setOpenGlDrawCallback*(windowName: cstring; 
+proc setOpenGlDrawCallback*(windowName: cstring;
                             callback: TCvOpenGlDrawCallback; userdata: pointer){.
     cdecl, importc: "cvSetOpenGlDrawCallback", dynlib: highguidll.}
-proc setOpenGlContext*(windowName: cstring){.cdecl, 
+proc setOpenGlContext*(windowName: cstring){.cdecl,
     importc: "cvSetOpenGlContext", dynlib: highguidll.}
-proc updateWindow*(windowName: cstring){.cdecl, importc: "cvUpdateWindow", 
+proc updateWindow*(windowName: cstring){.cdecl, importc: "cvUpdateWindow",
     dynlib: highguidll.}
 
 #***************************************************************************************
-#                         Working with Video Files and Cameras                           
+#                         Working with Video Files and Cameras
 #***************************************************************************************
 
-# start capturing frames from video file 
+# start capturing frames from video file
 proc createFileCapture*(filename: cstring): ptr TCapture{.
     importc: "cvCreateFileCapture", dynlib: highguidll.}
-const 
+const
   CAP_ANY* = 0           # autodetect
   CAP_MIL* = 100         # MIL proprietary drivers
   CAP_VFW* = 200         # platform native
@@ -381,7 +381,7 @@ const # modes of the controlling registers (can be: auto, manual, auto single pu
   CAP_PROP_IOS_DEVICE_FLASH* = 9003
   CAP_PROP_IOS_DEVICE_WHITEBALANCE* = 9004
   CAP_PROP_IOS_DEVICE_TORCH* = 9005 # Properties of cameras available through Smartek Giganetix Ethernet Vision interface
-                                    # --- Vladimir Litvinenko (litvinenko.vladimir@gmail.com) --- 
+                                    # --- Vladimir Litvinenko (litvinenko.vladimir@gmail.com) ---
   CAP_PROP_GIGA_FRAME_OFFSET_X* = 10001
   CAP_PROP_GIGA_FRAME_OFFSET_Y* = 10002
   CAP_PROP_GIGA_FRAME_WIDTH_MAX* = 10003
@@ -389,31 +389,31 @@ const # modes of the controlling registers (can be: auto, manual, auto single pu
   CAP_PROP_GIGA_FRAME_SENS_WIDTH* = 10005
   CAP_PROP_GIGA_FRAME_SENS_HEIGH* = 10006
 
-# start capturing frames from camera: index = camera_index + domain_offset (CV_CAP_*) 
+# start capturing frames from camera: index = camera_index + domain_offset (CV_CAP_*)
 proc createCameraCapture*(index: cint): ptr TCapture{.
     importc: "cvCreateCameraCapture", dynlib: highguidll.}
 # grab a frame, return 1 on success, 0 on fail.
-#  this function is thought to be fast               
-proc grabFrame*(capture: ptr TCapture): cint{.importc: "cvGrabFrame", 
+#  this function is thought to be fast
+proc grabFrame*(capture: ptr TCapture): cint{.importc: "cvGrabFrame",
     dynlib: highguidll.}
 # get the frame grabbed with cvGrabFrame(..)
 #  This function may apply some frame processing like
 #  frame decompression, flipping etc.
-#  !!!DO NOT RELEASE or MODIFY the retrieved frame!!! 
+#  !!!DO NOT RELEASE or MODIFY the retrieved frame!!!
 proc retrieveFrame*(capture: ptr TCapture; streamIdx: cint): ptr TIplImage{.
     importc: "cvRetrieveFrame", dynlib: highguidll.}
 # Just a combination of cvGrabFrame and cvRetrieveFrame
-#   !!!DO NOT RELEASE or MODIFY the retrieved frame!!!      
+#   !!!DO NOT RELEASE or MODIFY the retrieved frame!!!
 proc queryFrame*(capture: ptr TCapture): ptr TIplImage{.
     importc: "cvQueryFrame", dynlib: highguidll.}
-# stop capturing/reading and free resources 
+# stop capturing/reading and free resources
 proc releaseCapture*(capture: ptr ptr TCapture){.
     importc: "cvReleaseCapture", dynlib: highguidll.}
 
-# retrieve or set capture properties 
+# retrieve or set capture properties
 proc getCaptureProperty*(capture: ptr TCapture; propertyId: cint): cdouble{.
     importc: "cvGetCaptureProperty", dynlib: highguidll.}
-proc setCaptureProperty*(capture: ptr TCapture; propertyId: cint; 
+proc setCaptureProperty*(capture: ptr TCapture; propertyId: cint;
                            value: cdouble): cint{.
     importc: "cvSetCaptureProperty", dynlib: highguidll.}
 # Return the type of the capturer (eg, CV_CAP_V4W, CV_CAP_UNICAP), which is unknown if created with CV_CAP_ANY
@@ -425,26 +425,26 @@ proc fOURCC*(c1, c2, c3, c4: char): cint =
          ((ord(c3).cint and 255) shl 16) + ((ord(c4).cint and 255) shl 24))
 
 
-const 
+const
   FOURCC_PROMPT* = -1  # Open Codec Selection Dialog (Windows only)
   FOURCC_DEFAULT* = fOURCC('I', 'Y', 'U', 'V') # Use default codec for specified filename (Linux only)
 
-# initialize video file writer 
-proc createVideoWriter*(filename: cstring; fourcc: cint; fps: cdouble; 
+# initialize video file writer
+proc createVideoWriter*(filename: cstring; fourcc: cint; fps: cdouble;
                           frameSize: TSize; isColor: cint = 1): ptr TVideoWriter{.
     importc: "cvCreateVideoWriter", dynlib: highguidll.}
 
-# write frame to video file 
+# write frame to video file
 proc writeFrame*(writer: ptr TVideoWriter; image: ptr TIplImage): cint{.
     importc: "cvWriteFrame", dynlib: highguidll.}
-# close video file writer 
+# close video file writer
 proc releaseVideoWriter*(writer: ptr ptr TVideoWriter){.
     importc: "cvReleaseVideoWriter", dynlib: highguidll.}
 #***************************************************************************************\
 #                              Obsolete functions/synonyms                               *
-#\*************************************************************************************** 
-template captureFromFile*: expr = createFileCapture
-template captureFromCAM*(x: int): expr = createCameraCapture(x)
-template captureFromAVI*: expr = captureFromFile
-template createAVIWriter*: expr = createVideoWriter
-template writeToAVI*: expr = writeFrame
+#\***************************************************************************************
+template captureFromFile*: untyped = createFileCapture
+template captureFromCAM*(x: int): untyped = createCameraCapture(x)
+template captureFromAVI*: untyped = captureFromFile
+template createAVIWriter*: untyped = createVideoWriter
+template writeToAVI*: untyped = writeFrame

--- a/opencv/imgproc.nim
+++ b/opencv/imgproc.nim
@@ -41,61 +41,61 @@
 #//M
 
 {.deadCodeElim: on.}
-when defined(windows): 
-  const 
-    imgprocdll* = "(lib|)opencv_imgproc(249|231)d.dll"
-elif defined(macosx): 
-  const 
+when defined(windows):
+  const
+    imgprocdll* = "(lib|)opencv_imgproc(249|231|)(d|).dll"
+elif defined(macosx):
+  const
     imgprocdll* = "libopencv_imgproc.dylib"
-else: 
-  const 
+else:
+  const
     imgprocdll* = "libopencv_imgproc.so"
 include opencv/imgproc/iptypes
 
 
 #********************** Background statistics accumulation ****************************
-# Adds image to accumulator 
+# Adds image to accumulator
 
-proc acc*(image: ptr TArr; sum: ptr TArr; mask: ptr TArr = nil) {.cdecl, 
+proc acc*(image: ImgPtr; sum: ImgPtr; mask: ImgPtr = nil) {.cdecl,
     importc: "cvAcc", dynlib: imgprocdll.}
-# Adds squared image to accumulator 
+# Adds squared image to accumulator
 
-proc squareAcc*(image: ptr TArr; sqsum: ptr TArr; mask: ptr TArr = nil) {.cdecl, 
+proc squareAcc*(image: ImgPtr; sqsum: ImgPtr; mask: ImgPtr = nil) {.cdecl,
     importc: "cvSquareAcc", dynlib: imgprocdll.}
-# Adds a product of two images to accumulator 
+# Adds a product of two images to accumulator
 
-proc multiplyAcc*(image1: ptr TArr; image2: ptr TArr; acc: ptr TArr; 
-                  mask: ptr TArr = nil) {.cdecl, importc: "cvMultiplyAcc", 
+proc multiplyAcc*(image1: ImgPtr; image2: ImgPtr; acc: ImgPtr;
+                  mask: ImgPtr = nil) {.cdecl, importc: "cvMultiplyAcc",
     dynlib: imgprocdll.}
-# Adds image to accumulator with weights: acc = acc*(1-alpha) + image*alpha 
+# Adds image to accumulator with weights: acc = acc*(1-alpha) + image*alpha
 
-proc runningAvg*(image: ptr TArr; acc: ptr TArr; alpha: cdouble; 
-                 mask: ptr TArr = nil) {.cdecl, importc: "cvRunningAvg", 
+proc runningAvg*(image: ImgPtr; acc: ImgPtr; alpha: cdouble;
+                 mask: ImgPtr = nil) {.cdecl, importc: "cvRunningAvg",
     dynlib: imgprocdll.}
 #***************************************************************************************\
 #                                    Image Processing                                    *
 #\***************************************************************************************
 # Copies source 2D array inside of the larger destination array and
-#   makes a border of the specified type (IPL_BORDER_*) around the copied area. 
+#   makes a border of the specified type (IPL_BORDER_*) around the copied area.
 
-proc copyMakeBorder*(src: ptr TArr; dst: ptr TArr; offset: TPoint; 
-                     bordertype: cint; value: TScalar = scalarAll(0)) {.cdecl, 
+proc copyMakeBorder*(src: ImgPtr; dst: ImgPtr; offset: TPoint;
+                     bordertype: cint; value: TScalar = scalarAll(0)) {.cdecl,
     importc: "cvCopyMakeBorder", dynlib: imgprocdll.}
-# Smoothes array (removes noise) 
+# Smoothes array (removes noise)
 
-proc smooth*(src: ptr TArr; dst: ptr TArr; smoothtype: cint = GAUSSIAN; 
-             size1: cint = 3; size2: cint = 0; sigma1: cdouble = 0; 
-             sigma2: cdouble = 0) {.cdecl, importc: "cvSmooth", 
+proc smooth*(src: ImgPtr; dst: ImgPtr; smoothtype: cint = GAUSSIAN;
+             size1: cint = 3; size2: cint = 0; sigma1: cdouble = 0;
+             sigma2: cdouble = 0) {.cdecl, importc: "cvSmooth",
                                     dynlib: imgprocdll.}
-# Convolves the image with the kernel 
+# Convolves the image with the kernel
 
-proc filter2D*(src: ptr TArr; dst: ptr TArr; kernel: ptr TMat; 
-               anchor: TPoint = point(- 1, - 1)) {.cdecl, importc: "cvFilter2D", 
+proc filter2D*(src: ImgPtr; dst: ImgPtr; kernel: MatPtr;
+               anchor: TPoint = point(- 1, - 1)) {.cdecl, importc: "cvFilter2D",
     dynlib: imgprocdll.}
-# Finds integral image: SUM(X,Y) = sum(x<X,y<Y)I(x,y) 
+# Finds integral image: SUM(X,Y) = sum(x<X,y<Y)I(x,y)
 
-proc integral*(image: ptr TArr; sum: ptr TArr; sqsum: ptr TArr = nil; 
-               tiltedSum: ptr TArr = nil) {.cdecl, importc: "cvIntegral", 
+proc integral*(image: ImgPtr; sum: ImgPtr; sqsum: ImgPtr = nil;
+               tiltedSum: ImgPtr = nil) {.cdecl, importc: "cvIntegral",
     dynlib: imgprocdll.}
 #
 #   Smoothes the input image with gaussian kernel and then down-samples it.
@@ -103,7 +103,7 @@ proc integral*(image: ptr TArr; sum: ptr TArr; sqsum: ptr TArr = nil;
 #   dst_height = floor(src_height/2)[+1]
 #
 
-proc pyrDown*(src: ptr TArr; dst: ptr TArr; filter: cint = GAUSSIAN_5x5) {.
+proc pyrDown*(src: ImgPtr; dst: ImgPtr; filter: cint = GAUSSIAN_5x5) {.
     cdecl, importc: "cvPyrDown", dynlib: imgprocdll.}
 #
 #   Up-samples image and smoothes the result with gaussian kernel.
@@ -111,176 +111,177 @@ proc pyrDown*(src: ptr TArr; dst: ptr TArr; filter: cint = GAUSSIAN_5x5) {.
 #   dst_height = src_height*2
 #
 
-proc pyrUp*(src: ptr TArr; dst: ptr TArr; filter: cint = GAUSSIAN_5x5) {.cdecl, 
+proc pyrUp*(src: ImgPtr; dst: ImgPtr; filter: cint = GAUSSIAN_5x5) {.cdecl,
     importc: "cvPyrUp", dynlib: imgprocdll.}
-# Builds pyramid for an image 
+# Builds pyramid for an image
 
-proc createPyramid*(img: ptr TArr; extraLayers: cint; rate: cdouble; 
-                    layerSizes: ptr TSize = nil; bufarr: ptr TArr = nil; 
-                    calc: cint = 1; filter: cint = GAUSSIAN_5x5): ptr ptr TMat {.
+proc createPyramid*(img: ImgPtr; extraLayers: cint; rate: cdouble;
+                    layerSizes: ptr TSize = nil; bufarr: ImgPtr = nil;
+                    calc: cint = 1; filter: cint = GAUSSIAN_5x5): ptr MatPtr {.
     cdecl, importc: "cvCreatePyramid", dynlib: imgprocdll.}
-# Releases pyramid 
+# Releases pyramid
 
-proc releasePyramid*(pyramid: ptr ptr ptr TMat; extraLayers: cint) {.cdecl, 
+proc releasePyramid*(pyramid: ptr ptr MatPtr; extraLayers: cint) {.cdecl,
     importc: "cvReleasePyramid", dynlib: imgprocdll.}
-# Filters image using meanshift algorithm 
+# Filters image using meanshift algorithm
 
-proc pyrMeanShiftFiltering*(src: ptr TArr; dst: ptr TArr; sp: cdouble; 
+proc pyrMeanShiftFiltering*(src: ImgPtr; dst: ImgPtr; sp: cdouble;
                             sr: cdouble; maxLevel: cint = 1; termcrit: TTermCriteria = termCriteria(
-    TERMCRIT_ITER + TERMCRIT_EPS, 5, 1)) {.cdecl, 
+    TERMCRIT_ITER + TERMCRIT_EPS, 5, 1)) {.cdecl,
     importc: "cvPyrMeanShiftFiltering", dynlib: imgprocdll.}
-# Segments image using seed "markers" 
+# Segments image using seed "markers"
 
-proc watershed*(image: ptr TArr; markers: ptr TArr) {.cdecl, 
+proc watershed*(image: ImgPtr; markers: ImgPtr) {.cdecl,
     importc: "cvWatershed", dynlib: imgprocdll.}
 # Calculates an image derivative using generalized Sobel
 #   (aperture_size = 1,3,5,7) or Scharr (aperture_size = -1) operator.
-#   Scharr can be used only for the first dx or dy derivative 
+#   Scharr can be used only for the first dx or dy derivative
 
-proc sobel*(src: ptr TArr; dst: ptr TArr; xorder: cint; yorder: cint; 
-            apertureSize: cint = 3) {.cdecl, importc: "cvSobel", 
+proc sobel*(src: ImgPtr; dst: ImgPtr; xorder: cint; yorder: cint;
+            apertureSize: cint = 3) {.cdecl, importc: "cvSobel",
                                        dynlib: imgprocdll.}
-# Calculates the image Laplacian: (d2/dx + d2/dy)I 
+# Calculates the image Laplacian: (d2/dx + d2/dy)I
 
-proc laplace*(src: ptr TArr; dst: ptr TArr; apertureSize: cint = 3) {.cdecl, 
+proc laplace*(src: ImgPtr; dst: ImgPtr; apertureSize: cint = 3) {.cdecl,
     importc: "cvLaplace", dynlib: imgprocdll.}
-# Converts input array pixels from one color space to another 
+# Converts input array pixels from one color space to another
 
-proc cvtColor*(src: ptr TArr; dst: ptr TArr; code: cint) {.cdecl, 
+proc cvtColor*(src: ImgPtr; dst: ImgPtr; code: cint) {.cdecl,
     importc: "cvCvtColor", dynlib: imgprocdll.}
-# Resizes image (input array is resized to fit the destination array) 
+# Resizes image (input array is resized to fit the destination array)
 
-proc resize*(src: ptr TArr; dst: ptr TArr; interpolation: cint = INTER_LINEAR) {.
+proc resize*(src: ImgPtr; dst: ImgPtr; interpolation: cint = INTER_LINEAR) {.
     cdecl, importc: "cvResize", dynlib: imgprocdll.}
-# Warps image with affine transform 
+# Warps image with affine transform
 
-proc warpAffine*(src: ptr TArr; dst: ptr TArr; mapMatrix: ptr TMat; 
-                 flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS; 
-                 fillval: TScalar = scalarAll(0)) {.cdecl, 
+proc warpAffine*(src: ImgPtr; dst: ImgPtr; mapMatrix: MatPtr;
+                 flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS;
+                 fillval: TScalar = scalarAll(0)) {.cdecl,
     importc: "cvWarpAffine", dynlib: imgprocdll.}
-# Computes affine transform matrix for mapping src[i] to dst[i] (i=0,1,2) 
+# Computes affine transform matrix for mapping src[i] to dst[i] (i=0,1,2)
 
-proc getAffineTransform*(src: ptr TPoint2D32f; dst: ptr TPoint2D32f; 
-                         mapMatrix: ptr TMat): ptr TMat {.cdecl, 
+proc getAffineTransform*(src: ptr TPoint2D32f; dst: ptr TPoint2D32f;
+                         mapMatrix: MatPtr): MatPtr {.cdecl,
     importc: "cvGetAffineTransform", dynlib: imgprocdll.}
-# Computes rotation_matrix matrix 
+# Computes rotation_matrix matrix
 
-proc rotationMatrix2D*(center: TPoint2D32f; angle: cdouble; scale: cdouble; 
-                       mapMatrix: ptr TMat): ptr TMat {.cdecl, 
+proc rotationMatrix2D*(center: TPoint2D32f; angle: cdouble; scale: cdouble;
+                       mapMatrix: MatPtr): MatPtr {.cdecl,
     importc: "cv2DRotationMatrix", dynlib: imgprocdll.}
-# Warps image with perspective (projective) transform 
+# Warps image with perspective (projective) transform
 
-proc warpPerspective*(src: ptr TArr; dst: ptr TArr; mapMatrix: ptr TMat; 
-                      flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS; 
-                      fillval: TScalar = scalarAll(0)) {.cdecl, 
+proc warpPerspective*(src: ImgPtr; dst: ImgPtr; mapMatrix: MatPtr;
+                      flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS;
+                      fillval: TScalar = scalarAll(0)) {.cdecl,
     importc: "cvWarpPerspective", dynlib: imgprocdll.}
-# Computes perspective transform matrix for mapping src[i] to dst[i] (i=0,1,2,3) 
+# Computes perspective transform matrix for mapping src[i] to dst[i] (i=0,1,2,3)
 
-proc getPerspectiveTransform*(src: ptr TPoint2D32f; dst: ptr TPoint2D32f; 
-                              mapMatrix: ptr TMat): ptr TMat {.cdecl, 
+proc getPerspectiveTransform*(src: ptr TPoint2D32f; dst: ptr TPoint2D32f;
+                              mapMatrix: MatPtr): MatPtr {.cdecl,
     importc: "cvGetPerspectiveTransform", dynlib: imgprocdll.}
-# Performs generic geometric transformation using the specified coordinate maps 
+# Performs generic geometric transformation using the specified coordinate maps
 
-proc remap*(src: ptr TArr; dst: ptr TArr; mapx: ptr TArr; mapy: ptr TArr; 
-            flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS; 
-            fillval: TScalar = scalarAll(0)) {.cdecl, importc: "cvRemap", 
+proc remap*(src: ImgPtr; dst: ImgPtr; mapx: ImgPtr; mapy: ImgPtr;
+            flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS;
+            fillval: TScalar = scalarAll(0)) {.cdecl, importc: "cvRemap",
     dynlib: imgprocdll.}
-# Converts mapx & mapy from floating-point to integer formats for cvRemap 
+# Converts mapx & mapy from floating-point to integer formats for cvRemap
 
-proc convertMaps*(mapx: ptr TArr; mapy: ptr TArr; mapxy: ptr TArr; 
-                  mapalpha: ptr TArr) {.cdecl, importc: "cvConvertMaps", 
+proc convertMaps*(mapx: ImgPtr; mapy: ImgPtr; mapxy: ImgPtr;
+                  mapalpha: ImgPtr) {.cdecl, importc: "cvConvertMaps",
                                         dynlib: imgprocdll.}
-# Performs forward or inverse log-polar image transform 
+# Performs forward or inverse log-polar image transform
 
-proc logPolar*(src: ptr TArr; dst: ptr TArr; center: TPoint2D32f; m: cdouble; 
-               flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS) {.cdecl, 
+proc logPolar*(src: ImgPtr; dst: ImgPtr; center: TPoint2D32f; m: cdouble;
+               flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS) {.cdecl,
     importc: "cvLogPolar", dynlib: imgprocdll.}
-# Performs forward or inverse linear-polar image transform 
+# Performs forward or inverse linear-polar image transform
 
-proc linearPolar*(src: ptr TArr; dst: ptr TArr; center: TPoint2D32f; 
-                  maxRadius: cdouble; 
-                  flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS) {.cdecl, 
+proc linearPolar*(src: ImgPtr; dst: ImgPtr; center: TPoint2D32f;
+                  maxRadius: cdouble;
+                  flags: cint = INTER_LINEAR + WARP_FILL_OUTLIERS) {.cdecl,
     importc: "cvLinearPolar", dynlib: imgprocdll.}
-# Transforms the input image to compensate lens distortion 
+# Transforms the input image to compensate lens distortion
 
-proc undistort2*(src: ptr TArr; dst: ptr TArr; cameraMatrix: ptr TMat; 
-                 distortionCoeffs: ptr TMat; newCameraMatrix: ptr TMat = nil) {.
+proc undistort2*(src: ImgPtr; dst: ImgPtr; cameraMatrix: MatPtr;
+                 distortionCoeffs: MatPtr; newCameraMatrix: MatPtr = nil) {.
     cdecl, importc: "cvUndistort2", dynlib: imgprocdll.}
 # Computes transformation map from intrinsic camera parameters
-#   that can used by cvRemap 
+#   that can used by cvRemap
 
-proc initUndistortMap*(cameraMatrix: ptr TMat; distortionCoeffs: ptr TMat; 
-                       mapx: ptr TArr; mapy: ptr TArr) {.cdecl, 
+proc initUndistortMap*(cameraMatrix: MatPtr; distortionCoeffs: MatPtr;
+                       mapx: ImgPtr; mapy: ImgPtr) {.cdecl,
     importc: "cvInitUndistortMap", dynlib: imgprocdll.}
-# Computes undistortion+rectification map for a head of stereo camera 
+# Computes undistortion+rectification map for a head of stereo camera
 
-proc initUndistortRectifyMap*(cameraMatrix: ptr TMat; distCoeffs: ptr TMat; 
-                              r: ptr TMat; newCameraMatrix: ptr TMat; 
-                              mapx: ptr TArr; mapy: ptr TArr) {.cdecl, 
+proc initUndistortRectifyMap*(cameraMatrix: MatPtr; distCoeffs: MatPtr;
+                              r: MatPtr; newCameraMatrix: MatPtr;
+                              mapx: ImgPtr; mapy: ImgPtr) {.cdecl,
     importc: "cvInitUndistortRectifyMap", dynlib: imgprocdll.}
 # Computes the original (undistorted) feature coordinates
-#   from the observed (distorted) coordinates 
+#   from the observed (distorted) coordinates
 
-proc undistortPoints*(src: ptr TMat; dst: ptr TMat; cameraMatrix: ptr TMat; 
-                      distCoeffs: ptr TMat; r: ptr TMat = nil; p: ptr TMat = nil) {.
+proc undistortPoints*(src: MatPtr; dst: MatPtr; cameraMatrix: MatPtr;
+                      distCoeffs: MatPtr; r: MatPtr = nil; p: MatPtr = nil) {.
     cdecl, importc: "cvUndistortPoints", dynlib: imgprocdll.}
-# creates structuring element used for morphological operations 
+# creates structuring element used for morphological operations
 
-proc createStructuringElementEx*(cols: cint; rows: cint; anchorX: cint; 
-                                 anchorY: cint; shape: cint; 
+proc createStructuringElementEx*(cols: cint; rows: cint; anchorX: cint;
+                                 anchorY: cint; shape: cint;
                                  values: ptr cint = nil): ptr TIplConvKernel {.
     cdecl, importc: "cvCreateStructuringElementEx", dynlib: imgprocdll.}
-# releases structuring element 
+# releases structuring element
 
-proc releaseStructuringElement*(element: ptr ptr TIplConvKernel) {.cdecl, 
+proc releaseStructuringElement*(element: ptr ptr TIplConvKernel) {.cdecl,
     importc: "cvReleaseStructuringElement", dynlib: imgprocdll.}
 # erodes input image (applies minimum filter) one or more times.
-#   If element pointer is NULL, 3x3 rectangular element is used 
+#   If element pointer is NULL, 3x3 rectangular element is used
 
-proc erode*(src: ptr TArr; dst: ptr TArr; element: ptr TIplConvKernel = nil; 
-            iterations: cint = 1) {.cdecl, importc: "cvErode", 
+proc erode*(src: ImgPtr; dst: ImgPtr; element: ptr TIplConvKernel = nil;
+            iterations: cint = 1) {.cdecl, importc: "cvErode",
                                     dynlib: imgprocdll.}
 # dilates input image (applies maximum filter) one or more times.
-#   If element pointer is NULL, 3x3 rectangular element is used 
+#   If element pointer is NULL, 3x3 rectangular element is used
 
-proc dilate*(src: ptr TArr; dst: ptr TArr; element: ptr TIplConvKernel = nil; 
-             iterations: cint = 1) {.cdecl, importc: "cvDilate", 
+proc dilate*(src: ImgPtr; dst: ImgPtr; element: ptr TIplConvKernel = nil;
+             iterations: cint = 1) {.cdecl, importc: "cvDilate",
                                      dynlib: imgprocdll.}
-# Performs complex morphological transformation 
+# Performs complex morphological transformation
 
-proc morphologyEx*(src: ptr TArr; dst: ptr TArr; temp: ptr TArr; 
-                   element: ptr TIplConvKernel; operation: cint; 
-                   iterations: cint = 1) {.cdecl, importc: "cvMorphologyEx", 
+proc morphologyEx*(src: ImgPtr; dst: ImgPtr; temp: ImgPtr;
+                   element: ptr TIplConvKernel; operation: cint;
+                   iterations: cint = 1) {.cdecl, importc: "cvMorphologyEx",
     dynlib: imgprocdll.}
-# Calculates all spatial and central moments up to the 3rd order 
+# Calculates all spatial and central moments up to the 3rd order
 
-proc moments*(arr: ptr TArr; moments: ptr TMoments; binary: cint = 0) {.cdecl, 
+proc moments*(arr: ImgPtr; moments: ptr TMoments; binary: cint = 0) {.cdecl,
     importc: "cvMoments", dynlib: imgprocdll.}
-# Retrieve particular spatial, central or normalized central moments 
+# Retrieve particular spatial, central or normalized central moments
 
 proc getSpatialMoment*(moments: ptr TMoments; xOrder: cint; yOrder: cint): cdouble {.
     cdecl, importc: "cvGetSpatialMoment", dynlib: imgprocdll.}
 proc getCentralMoment*(moments: ptr TMoments; xOrder: cint; yOrder: cint): cdouble {.
     cdecl, importc: "cvGetCentralMoment", dynlib: imgprocdll.}
-proc getNormalizedCentralMoment*(moments: ptr TMoments; xOrder: cint; 
-                                 yOrder: cint): cdouble {.cdecl, 
+proc getNormalizedCentralMoment*(moments: ptr TMoments; xOrder: cint;
+                                 yOrder: cint): cdouble {.cdecl,
     importc: "cvGetNormalizedCentralMoment", dynlib: imgprocdll.}
-# Calculates 7 Hu's invariants from precalculated spatial and central moments 
+# Calculates 7 Hu's invariants from precalculated spatial and central moments
 
-proc getHuMoments*(moments: ptr TMoments; huMoments: ptr THuMoments) {.cdecl, 
+proc getHuMoments*(moments: ptr TMoments; huMoments: ptr THuMoments) {.cdecl,
     importc: "cvGetHuMoments", dynlib: imgprocdll.}
+
 #********************************** data sampling *************************************
 # Fetches pixels that belong to the specified line segment and stores them to the buffer.
-#   Returns the number of retrieved points. 
+#   Returns the number of retrieved points.
 
-proc sampleLine*(image: ptr TArr; pt1: TPoint; pt2: TPoint; buffer: pointer; 
-                 connectivity: cint = 8): cint {.cdecl, importc: "cvSampleLine", 
+proc sampleLine*(image: ImgPtr; pt1: TPoint; pt2: TPoint; buffer: pointer;
+                 connectivity: cint = 8): cint {.cdecl, importc: "cvSampleLine",
     dynlib: imgprocdll.}
 # Retrieves the rectangular image region with specified center from the input array.
 # dst(x,y) <- src(x + center.x - dst_width/2, y + center.y - dst_height/2).
 # Values of pixels with fractional coordinates are retrieved using bilinear interpolation
 
-proc getRectSubPix*(src: ptr TArr; dst: ptr TArr; center: TPoint2D32f) {.cdecl, 
+proc getRectSubPix*(src: ImgPtr; dst: ImgPtr; center: TPoint2D32f) {.cdecl,
     importc: "cvGetRectSubPix", dynlib: imgprocdll.}
 # Retrieves quadrangle from the input array.
 #    matrixarr = ( a11  a12 | b1 )   dst(x,y) <- src(A[x y]' + b)
@@ -288,325 +289,325 @@ proc getRectSubPix*(src: ptr TArr; dst: ptr TArr; center: TPoint2D32f) {.cdecl,
 #                                     with fractional coordinates)
 #
 
-proc getQuadrangleSubPix*(src: ptr TArr; dst: ptr TArr; mapMatrix: ptr TMat) {.
+proc getQuadrangleSubPix*(src: ImgPtr; dst: ImgPtr; mapMatrix: MatPtr) {.
     cdecl, importc: "cvGetQuadrangleSubPix", dynlib: imgprocdll.}
 # Measures similarity between template and overlapped windows in the source image
-#   and fills the resultant image with the measurements 
+#   and fills the resultant image with the measurements
 
-proc matchTemplate*(image: ptr TArr; templ: ptr TArr; result: ptr TArr; 
-                    theMethod: cint) {.cdecl, importc: "cvMatchTemplate", 
+proc matchTemplate*(image: ImgPtr; templ: ImgPtr; result: ImgPtr;
+                    theMethod: cint) {.cdecl, importc: "cvMatchTemplate",
                                     dynlib: imgprocdll.}
 # Computes earth mover distance between
-#   two weighted point sets (called signatures) 
+#   two weighted point sets (called signatures)
 
-proc calcEMD2*(signature1: ptr TArr; signature2: ptr TArr; distanceType: cint; 
-               distanceFunc: TDistanceFunction = nil; 
-               costMatrix: ptr TArr = nil; flow: ptr TArr = nil; 
+proc calcEMD2*(signature1: ImgPtr; signature2: ImgPtr; distanceType: cint;
+               distanceFunc: TDistanceFunction = nil;
+               costMatrix: ImgPtr = nil; flow: ImgPtr = nil;
                lowerBound: ptr cfloat = nil; userdata: pointer = nil): cfloat {.
     cdecl, importc: "cvCalcEMD2", dynlib: imgprocdll.}
 #***************************************************************************************\
 #                              Contours retrieving                                       *
 #\***************************************************************************************
 # Retrieves outer and optionally inner boundaries of white (non-zero) connected
-#   components in the black (zero) background 
+#   components in the black (zero) background
 
-proc findContours*(image: ptr TArr; storage: ptr TMemStorage; 
-                   firstContour: ptr ptr TSeq; 
-                   headerSize: cint = sizeof(TContour).cint; mode: cint = RETR_LIST; 
-                   theMethod: cint = CHAIN_APPROX_SIMPLE; 
-                   offset: TPoint = point(0, 0)): cint {.cdecl, 
+proc findContours*(image: ImgPtr; storage: ptr TMemStorage;
+                   firstContour: ptr ptr TSeq;
+                   headerSize: cint = sizeof(TContour).cint; mode: cint = RETR_LIST;
+                   theMethod: cint = CHAIN_APPROX_SIMPLE;
+                   offset: TPoint = point(0, 0)): cint {.cdecl,
     importc: "cvFindContours", dynlib: imgprocdll.}
 # Initalizes contour retrieving process.
 #   Calls cvStartFindContours.
 #   Calls cvFindNextContour until null pointer is returned
 #   or some other condition becomes true.
-#   Calls cvEndFindContours at the end. 
+#   Calls cvEndFindContours at the end.
 
-proc startFindContours*(image: ptr TArr; storage: ptr TMemStorage; 
-                        headerSize: cint = sizeof(TContour).cint; 
-                        mode: cint = RETR_LIST; 
-                        theMethod: cint = CHAIN_APPROX_SIMPLE; 
-                        offset: TPoint = point(0, 0)): TContourScanner {.cdecl, 
+proc startFindContours*(image: ImgPtr; storage: ptr TMemStorage;
+                        headerSize: cint = sizeof(TContour).cint;
+                        mode: cint = RETR_LIST;
+                        theMethod: cint = CHAIN_APPROX_SIMPLE;
+                        offset: TPoint = point(0, 0)): TContourScanner {.cdecl,
     importc: "cvStartFindContours", dynlib: imgprocdll.}
-# Retrieves next contour 
+# Retrieves next contour
 
-proc findNextContour*(scanner: TContourScanner): ptr TSeq {.cdecl, 
+proc findNextContour*(scanner: TContourScanner): ptr TSeq {.cdecl,
     importc: "cvFindNextContour", dynlib: imgprocdll.}
 # Substitutes the last retrieved contour with the new one
-#   (if the substitutor is null, the last retrieved contour is removed from the tree) 
+#   (if the substitutor is null, the last retrieved contour is removed from the tree)
 
 proc substituteContour*(scanner: TContourScanner; newContour: ptr TSeq) {.
     cdecl, importc: "cvSubstituteContour", dynlib: imgprocdll.}
-# Releases contour scanner and returns pointer to the first outer contour 
+# Releases contour scanner and returns pointer to the first outer contour
 
-proc endFindContours*(scanner: ptr TContourScanner): ptr TSeq {.cdecl, 
+proc endFindContours*(scanner: ptr TContourScanner): ptr TSeq {.cdecl,
     importc: "cvEndFindContours", dynlib: imgprocdll.}
-# Approximates a single Freeman chain or a tree of chains to polygonal curves 
+# Approximates a single Freeman chain or a tree of chains to polygonal curves
 
-proc approxChains*(srcSeq: ptr TSeq; storage: ptr TMemStorage; 
-                   theMethod: cint = CHAIN_APPROX_SIMPLE; parameter: cdouble = 0; 
+proc approxChains*(srcSeq: ptr TSeq; storage: ptr TMemStorage;
+                   theMethod: cint = CHAIN_APPROX_SIMPLE; parameter: cdouble = 0;
                    minimalPerimeter: cint = 0; recursive: cint = 0): ptr TSeq {.
     cdecl, importc: "cvApproxChains", dynlib: imgprocdll.}
 # Initalizes Freeman chain reader.
 #   The reader is used to iteratively get coordinates of all the chain points.
-#   If the Freeman codes should be read as is, a simple sequence reader should be used 
+#   If the Freeman codes should be read as is, a simple sequence reader should be used
 
 proc startReadChainPoints*(chain: ptr TChain; reader: ptr TChainPtReader) {.
     cdecl, importc: "cvStartReadChainPoints", dynlib: imgprocdll.}
-# Retrieves the next chain point 
+# Retrieves the next chain point
 
-proc readChainPoint*(reader: ptr TChainPtReader): TPoint {.cdecl, 
+proc readChainPoint*(reader: ptr TChainPtReader): TPoint {.cdecl,
     importc: "cvReadChainPoint", dynlib: imgprocdll.}
 #***************************************************************************************\
 #                            Contour Processing and Shape Analysis                       *
 #\***************************************************************************************
 # Approximates a single polygonal curve (contour) or
-#   a tree of polygonal curves (contours) 
+#   a tree of polygonal curves (contours)
 
-proc approxPoly*(srcSeq: pointer; headerSize: cint; storage: ptr TMemStorage; 
+proc approxPoly*(srcSeq: pointer; headerSize: cint; storage: ptr TMemStorage;
                  theMethod: cint; eps: cdouble; recursive: cint = 0): ptr TSeq {.
     cdecl, importc: "cvApproxPoly", dynlib: imgprocdll.}
-# Calculates perimeter of a contour or length of a part of contour 
+# Calculates perimeter of a contour or length of a part of contour
 
 proc arcLength*(curve: pointer; slice: core.TSlice = Whole_Seq; isClosed: cint = - 1): cdouble {.
     cdecl, importc: "cvArcLength", dynlib: imgprocdll.}
-proc contourPerimeter*(contour: pointer): cdouble {.inline, cdecl.} = 
+proc contourPerimeter*(contour: pointer): cdouble {.inline, cdecl.} =
   return arcLength(contour, Whole_Seq, 1)
 
 # Calculates contour boundning rectangle (update=1) or
-#   just retrieves pre-calculated rectangle (update=0) 
+#   just retrieves pre-calculated rectangle (update=0)
 
-proc boundingRect*(points: ptr TArr; update: cint = 0): TRect {.cdecl, 
+proc boundingRect*(points: ImgPtr; update: cint = 0): TRect {.cdecl,
     importc: "cvBoundingRect", dynlib: imgprocdll.}
-# Calculates area of a contour or contour segment 
+# Calculates area of a contour or contour segment
 
-proc contourArea*(contour: ptr TArr; slice: core.TSlice = Whole_Seq; 
-                  oriented: cint = 0): cdouble {.cdecl, 
+proc contourArea*(contour: ImgPtr; slice: core.TSlice = Whole_Seq;
+                  oriented: cint = 0): cdouble {.cdecl,
     importc: "cvContourArea", dynlib: imgprocdll.}
-# Finds minimum area rotated rectangle bounding a set of points 
+# Finds minimum area rotated rectangle bounding a set of points
 
-proc minAreaRect2*(points: ptr TArr; storage: ptr TMemStorage = nil): TBox2D {.
+proc minAreaRect2*(points: ImgPtr; storage: ptr TMemStorage = nil): TBox2D {.
     cdecl, importc: "cvMinAreaRect2", dynlib: imgprocdll.}
-# Finds minimum enclosing circle for a set of points 
+# Finds minimum enclosing circle for a set of points
 
-proc minEnclosingCircle*(points: ptr TArr; center: ptr TPoint2D32f; 
-                         radius: ptr cfloat): cint {.cdecl, 
+proc minEnclosingCircle*(points: ImgPtr; center: ptr TPoint2D32f;
+                         radius: ptr cfloat): cint {.cdecl,
     importc: "cvMinEnclosingCircle", dynlib: imgprocdll.}
-# Compares two contours by matching their moments 
+# Compares two contours by matching their moments
 
-proc matchShapes*(object1: pointer; object2: pointer; theMethod: cint; 
-                  parameter: cdouble = 0): cdouble {.cdecl, 
+proc matchShapes*(object1: pointer; object2: pointer; theMethod: cint;
+                  parameter: cdouble = 0): cdouble {.cdecl,
     importc: "cvMatchShapes", dynlib: imgprocdll.}
-# Calculates exact convex hull of 2d point set 
+# Calculates exact convex hull of 2d point set
 
-proc convexHull2*(input: ptr TArr; hullStorage: pointer = nil; 
+proc convexHull2*(input: ImgPtr; hullStorage: pointer = nil;
                   orientation: cint = CLOCKWISE; returnPoints: cint = 0): ptr TSeq {.
     cdecl, importc: "cvConvexHull2", dynlib: imgprocdll.}
-# Checks whether the contour is convex or not (returns 1 if convex, 0 if not) 
+# Checks whether the contour is convex or not (returns 1 if convex, 0 if not)
 
-proc checkContourConvexity*(contour: ptr TArr): cint {.cdecl, 
+proc checkContourConvexity*(contour: ImgPtr): cint {.cdecl,
     importc: "cvCheckContourConvexity", dynlib: imgprocdll.}
-# Finds convexity defects for the contour 
+# Finds convexity defects for the contour
 
-proc convexityDefects*(contour: ptr TArr; convexhull: ptr TArr; 
-                       storage: ptr TMemStorage = nil): ptr TSeq {.cdecl, 
+proc convexityDefects*(contour: ImgPtr; convexhull: ImgPtr;
+                       storage: ptr TMemStorage = nil): ptr TSeq {.cdecl,
     importc: "cvConvexityDefects", dynlib: imgprocdll.}
-# Fits ellipse into a set of 2d points 
+# Fits ellipse into a set of 2d points
 
-proc fitEllipse2*(points: ptr TArr): TBox2D {.cdecl, importc: "cvFitEllipse2", 
+proc fitEllipse2*(points: ImgPtr): TBox2D {.cdecl, importc: "cvFitEllipse2",
     dynlib: imgprocdll.}
-# Finds minimum rectangle containing two given rectangles 
+# Finds minimum rectangle containing two given rectangles
 
-proc maxRect*(rect1: ptr TRect; rect2: ptr TRect): TRect {.cdecl, 
+proc maxRect*(rect1: ptr TRect; rect2: ptr TRect): TRect {.cdecl,
     importc: "cvMaxRect", dynlib: imgprocdll.}
-# Finds coordinates of the box vertices 
+# Finds coordinates of the box vertices
 
-proc boxPoints*(box: TBox2D; pt: array[0..4 - 1, TPoint2D32f]) {.cdecl, 
+proc boxPoints*(box: TBox2D; pt: array[0..4 - 1, TPoint2D32f]) {.cdecl,
     importc: "cvBoxPoints", dynlib: imgprocdll.}
 # Initializes sequence header for a matrix (column or row vector) of points -
-#   a wrapper for cvMakeSeqHeaderForArray (it does not initialize bounding rectangle!!!) 
+#   a wrapper for cvMakeSeqHeaderForArray (it does not initialize bounding rectangle!!!)
 
-proc pointSeqFromMat*(seqKind: cint; mat: ptr TArr; 
+proc pointSeqFromMat*(seqKind: cint; mat: ImgPtr;
                       contourHeader: ptr TContour; theBlock: ptr TSeqBlock): ptr TSeq {.
     cdecl, importc: "cvPointSeqFromMat", dynlib: imgprocdll.}
 # Checks whether the point is inside polygon, outside, on an edge (at a vertex).
 #   Returns positive, negative or zero value, correspondingly.
 #   Optionally, measures a signed distance between
-#   the point and the nearest polygon edge (measure_dist=1) 
+#   the point and the nearest polygon edge (measure_dist=1)
 
-proc pointPolygonTest*(contour: ptr TArr; pt: TPoint2D32f; measureDist: cint): cdouble {.
+proc pointPolygonTest*(contour: ImgPtr; pt: TPoint2D32f; measureDist: cint): cdouble {.
     cdecl, importc: "cvPointPolygonTest", dynlib: imgprocdll.}
 #***************************************************************************************\
 #                                  Histogram functions                                   *
 #\***************************************************************************************
-# Creates new histogram 
+# Creates new histogram
 
-proc createHist*(dims: cint; sizes: ptr cint; theType: cint; 
+proc createHist*(dims: cint; sizes: ptr cint; theType: cint;
                  ranges: ptr ptr cfloat = nil; uniform: cint = 1): ptr THistogram {.
     cdecl, importc: "cvCreateHist", dynlib: imgprocdll.}
-# Assignes histogram bin ranges 
+# Assignes histogram bin ranges
 
-proc setHistBinRanges*(hist: ptr THistogram; ranges: ptr ptr cfloat; 
-                       uniform: cint = 1) {.cdecl, 
+proc setHistBinRanges*(hist: ptr THistogram; ranges: ptr ptr cfloat;
+                       uniform: cint = 1) {.cdecl,
     importc: "cvSetHistBinRanges", dynlib: imgprocdll.}
-# Creates histogram header for array 
+# Creates histogram header for array
 
-proc makeHistHeaderForArray*(dims: cint; sizes: ptr cint; hist: ptr THistogram; 
-                             data: ptr cfloat; ranges: ptr ptr cfloat = nil; 
-                             uniform: cint = 1): ptr THistogram {.cdecl, 
+proc makeHistHeaderForArray*(dims: cint; sizes: ptr cint; hist: ptr THistogram;
+                             data: ptr cfloat; ranges: ptr ptr cfloat = nil;
+                             uniform: cint = 1): ptr THistogram {.cdecl,
     importc: "cvMakeHistHeaderForArray", dynlib: imgprocdll.}
-# Releases histogram 
+# Releases histogram
 
-proc releaseHist*(hist: ptr ptr THistogram) {.cdecl, importc: "cvReleaseHist", 
+proc releaseHist*(hist: ptr ptr THistogram) {.cdecl, importc: "cvReleaseHist",
     dynlib: imgprocdll.}
-# Clears all the histogram bins 
+# Clears all the histogram bins
 
-proc clearHist*(hist: ptr THistogram) {.cdecl, importc: "cvClearHist", 
+proc clearHist*(hist: ptr THistogram) {.cdecl, importc: "cvClearHist",
                                         dynlib: imgprocdll.}
-# Finds indices and values of minimum and maximum histogram bins 
+# Finds indices and values of minimum and maximum histogram bins
 
-proc getMinMaxHistValue*(hist: ptr THistogram; minValue: ptr cfloat; 
-                         maxValue: ptr cfloat; minIdx: ptr cint = nil; 
-                         maxIdx: ptr cint = nil) {.cdecl, 
+proc getMinMaxHistValue*(hist: ptr THistogram; minValue: ptr cfloat;
+                         maxValue: ptr cfloat; minIdx: ptr cint = nil;
+                         maxIdx: ptr cint = nil) {.cdecl,
     importc: "cvGetMinMaxHistValue", dynlib: imgprocdll.}
 # Normalizes histogram by dividing all bins by sum of the bins, multiplied by <factor>.
-#   After that sum of histogram bins is equal to <factor> 
+#   After that sum of histogram bins is equal to <factor>
 
-proc normalizeHist*(hist: ptr THistogram; factor: cdouble) {.cdecl, 
+proc normalizeHist*(hist: ptr THistogram; factor: cdouble) {.cdecl,
     importc: "cvNormalizeHist", dynlib: imgprocdll.}
-# Clear all histogram bins that are below the threshold 
+# Clear all histogram bins that are below the threshold
 
-proc threshHist*(hist: ptr THistogram; threshold: cdouble) {.cdecl, 
+proc threshHist*(hist: ptr THistogram; threshold: cdouble) {.cdecl,
     importc: "cvThreshHist", dynlib: imgprocdll.}
-# Compares two histogram 
+# Compares two histogram
 
 proc compareHist*(hist1: ptr THistogram; hist2: ptr THistogram; theMethod: cint): cdouble {.
     cdecl, importc: "cvCompareHist", dynlib: imgprocdll.}
 # Copies one histogram to another. Destination histogram is created if
-#   the destination pointer is NULL 
+#   the destination pointer is NULL
 
-proc copyHist*(src: ptr THistogram; dst: ptr ptr THistogram) {.cdecl, 
+proc copyHist*(src: ptr THistogram; dst: ptr ptr THistogram) {.cdecl,
     importc: "cvCopyHist", dynlib: imgprocdll.}
 # Calculates bayesian probabilistic histograms
-#   (each or src and dst is an array of <number> histograms 
+#   (each or src and dst is an array of <number> histograms
 
-proc calcBayesianProb*(src: ptr ptr THistogram; number: cint; 
-                       dst: ptr ptr THistogram) {.cdecl, 
+proc calcBayesianProb*(src: ptr ptr THistogram; number: cint;
+                       dst: ptr ptr THistogram) {.cdecl,
     importc: "cvCalcBayesianProb", dynlib: imgprocdll.}
-# Calculates array histogram 
+# Calculates array histogram
 
-proc calcArrHist*(arr: ptr ptr TArr; hist: ptr THistogram; accumulate: cint = 0; 
-                  mask: ptr TArr = nil) {.cdecl, importc: "cvCalcArrHist", 
+proc calcArrHist*(arr: ptr ImgPtr; hist: ptr THistogram; accumulate: cint = 0;
+                  mask: ImgPtr = nil) {.cdecl, importc: "cvCalcArrHist",
     dynlib: imgprocdll.}
-proc calcHist*(image: ptr ptr TIplImage; hist: ptr THistogram; 
-               accumulate: cint = 0; mask: ptr TArr = nil) {.inline, cdecl.} = 
-  calcArrHist(cast[ptr ptr TArr](image), hist, accumulate, mask)
+proc calcHist*(image: ptr ptr TIplImage; hist: ptr THistogram;
+               accumulate: cint = 0; mask: ImgPtr = nil) {.inline, cdecl.} =
+  calcArrHist(cast[ptr ImgPtr](image), hist, accumulate, mask)
 
-# Calculates back project 
+# Calculates back project
 
-proc calcArrBackProject*(image: ptr ptr TArr; dst: ptr TArr; 
-                         hist: ptr THistogram) {.cdecl, 
+proc calcArrBackProject*(image: ptr ImgPtr; dst: ImgPtr;
+                         hist: ptr THistogram) {.cdecl,
     importc: "cvCalcArrBackProject", dynlib: imgprocdll.}
-template calcBackProject*(image, dst, hist: expr): expr = 
-  CalcArrBackProject(cast[ptr ptr TArr](image), dst, hist)
+template calcBackProject*(image, dst, hist: untyped): untyped =
+  CalcArrBackProject(cast[ptr ImgPtr](image), dst, hist)
 
 # Does some sort of template matching but compares histograms of
-#   template and each window location 
+#   template and each window location
 
-proc calcArrBackProjectPatch*(image: ptr ptr TArr; dst: ptr TArr; range: TSize; 
-                              hist: ptr THistogram; theMethod: cint; 
-                              factor: cdouble) {.cdecl, 
+proc calcArrBackProjectPatch*(image: ptr ImgPtr; dst: ImgPtr; range: TSize;
+                              hist: ptr THistogram; theMethod: cint;
+                              factor: cdouble) {.cdecl,
     importc: "cvCalcArrBackProjectPatch", dynlib: imgprocdll.}
-template calcBackProjectPatch*(image, dst, range, hist, theMethod, factor: expr): expr = 
-  CalcArrBackProjectPatch(cast[ptr ptr TArr](image), dst, range, hist, theMethod, 
+template calcBackProjectPatch*(image, dst, range, hist, theMethod, factor: untyped): untyped =
+  CalcArrBackProjectPatch(cast[ptr ImgPtr](image), dst, range, hist, theMethod,
                           factor)
 
-# calculates probabilistic density (divides one histogram by another) 
+# calculates probabilistic density (divides one histogram by another)
 
-proc calcProbDensity*(hist1: ptr THistogram; hist2: ptr THistogram; 
-                      dstHist: ptr THistogram; scale: cdouble = 255) {.cdecl, 
+proc calcProbDensity*(hist1: ptr THistogram; hist2: ptr THistogram;
+                      dstHist: ptr THistogram; scale: cdouble = 255) {.cdecl,
     importc: "cvCalcProbDensity", dynlib: imgprocdll.}
-# equalizes histogram of 8-bit single-channel image 
+# equalizes histogram of 8-bit single-channel image
 
-proc equalizeHist*(src: ptr TArr; dst: ptr TArr) {.cdecl, 
+proc equalizeHist*(src: ImgPtr; dst: ImgPtr) {.cdecl,
     importc: "cvEqualizeHist", dynlib: imgprocdll.}
-# Applies distance transform to binary image 
+# Applies distance transform to binary image
 
-proc distTransform*(src: ptr TArr; dst: ptr TArr; distanceType: cint = DIST_L2; 
-                    maskSize: cint = 3; mask: ptr cfloat = nil; 
-                    labels: ptr TArr = nil; labelType: cint = DIST_LABEL_CCOMP) {.
+proc distTransform*(src: ImgPtr; dst: ImgPtr; distanceType: cint = DIST_L2;
+                    maskSize: cint = 3; mask: ptr cfloat = nil;
+                    labels: ImgPtr = nil; labelType: cint = DIST_LABEL_CCOMP) {.
     cdecl, importc: "cvDistTransform", dynlib: imgprocdll.}
 # Applies fixed-level threshold to grayscale image.
-#   This is a basic operation applied before retrieving contours 
+#   This is a basic operation applied before retrieving contours
 
-proc threshold*(src: ptr TArr; dst: ptr TArr; threshold: cdouble; 
-                maxValue: cdouble; thresholdType: cint): cdouble {.cdecl, 
+proc threshold*(src: ImgPtr; dst: ImgPtr; threshold: cdouble;
+                maxValue: cdouble; thresholdType: cint): cdouble {.cdecl,
     importc: "cvThreshold", dynlib: imgprocdll.}
 # Applies adaptive threshold to grayscale image.
 #   The two parameters for methods CV_ADAPTIVE_THRESH_MEAN_C and
 #   CV_ADAPTIVE_THRESH_GAUSSIAN_C are:
 #   neighborhood size (3, 5, 7 etc.),
-#   and a constant subtracted from mean (...,-3,-2,-1,0,1,2,3,...) 
+#   and a constant subtracted from mean (...,-3,-2,-1,0,1,2,3,...)
 
-proc adaptiveThreshold*(src: ptr TArr; dst: ptr TArr; maxValue: cdouble; 
-                        adaptiveMethod: cint = ADAPTIVE_THRESH_MEAN_C; 
-                        thresholdType: cint = THRESH_BINARY; 
-                        blockSize: cint = 3; param1: cdouble = 5) {.cdecl, 
+proc adaptiveThreshold*(src: ImgPtr; dst: ImgPtr; maxValue: cdouble;
+                        adaptiveMethod: cint = ADAPTIVE_THRESH_MEAN_C;
+                        thresholdType: cint = THRESH_BINARY;
+                        blockSize: cint = 3; param1: cdouble = 5) {.cdecl,
     importc: "cvAdaptiveThreshold", dynlib: imgprocdll.}
-# Fills the connected component until the color difference gets large enough 
+# Fills the connected component until the color difference gets large enough
 
-proc floodFill*(image: ptr TArr; seedPoint: TPoint; newVal: TScalar; 
-                loDiff: TScalar = scalarAll(0); 
-                upDiff: TScalar = scalarAll(0); comp: ptr TConnectedComp = nil; 
-                flags: cint = 4; mask: ptr TArr = nil) {.cdecl, 
+proc floodFill*(image: ImgPtr; seedPoint: TPoint; newVal: TScalar;
+                loDiff: TScalar = scalarAll(0);
+                upDiff: TScalar = scalarAll(0); comp: ptr TConnectedComp = nil;
+                flags: cint = 4; mask: ImgPtr = nil) {.cdecl,
     importc: "cvFloodFill", dynlib: imgprocdll.}
 #***************************************************************************************\
 #                                  Feature detection                                     *
 #\***************************************************************************************
-# Runs canny edge detector 
+# Runs canny edge detector
 
-proc canny*(image: ptr TArr; edges: ptr TArr; threshold1: cdouble; 
-            threshold2: cdouble; apertureSize: cint = 3) {.cdecl, 
+proc canny*(image: ImgPtr; edges: ImgPtr; threshold1: cdouble;
+            threshold2: cdouble; apertureSize: cint = 3) {.cdecl,
     importc: "cvCanny", dynlib: imgprocdll.}
 # Calculates constraint image for corner detection
 #   Dx^2 * Dyy + Dxx * Dy^2 - 2 * Dx * Dy * Dxy.
-#   Applying threshold to the result gives coordinates of corners 
+#   Applying threshold to the result gives coordinates of corners
 
-proc preCornerDetect*(image: ptr TArr; corners: ptr TArr; 
-                      apertureSize: cint = 3) {.cdecl, 
+proc preCornerDetect*(image: ImgPtr; corners: ImgPtr;
+                      apertureSize: cint = 3) {.cdecl,
     importc: "cvPreCornerDetect", dynlib: imgprocdll.}
 # Calculates eigen values and vectors of 2x2
-#   gradient covariation matrix at every image pixel 
+#   gradient covariation matrix at every image pixel
 
-proc cornerEigenValsAndVecs*(image: ptr TArr; eigenvv: ptr TArr; 
-                             blockSize: cint; apertureSize: cint = 3) {.cdecl, 
+proc cornerEigenValsAndVecs*(image: ImgPtr; eigenvv: ImgPtr;
+                             blockSize: cint; apertureSize: cint = 3) {.cdecl,
     importc: "cvCornerEigenValsAndVecs", dynlib: imgprocdll.}
 # Calculates minimal eigenvalue for 2x2 gradient covariation matrix at
-#   every image pixel 
+#   every image pixel
 
-proc cornerMinEigenVal*(image: ptr TArr; eigenval: ptr TArr; blockSize: cint; 
-                        apertureSize: cint = 3) {.cdecl, 
+proc cornerMinEigenVal*(image: ImgPtr; eigenval: ImgPtr; blockSize: cint;
+                        apertureSize: cint = 3) {.cdecl,
     importc: "cvCornerMinEigenVal", dynlib: imgprocdll.}
 # Harris corner detector:
-#   Calculates det(M) - k*(trace(M)^2), where M is 2x2 gradient covariation matrix for each pixel 
+#   Calculates det(M) - k*(trace(M)^2), where M is 2x2 gradient covariation matrix for each pixel
 
-proc cornerHarris*(image: ptr TArr; harrisResponce: ptr TArr; blockSize: cint; 
+proc cornerHarris*(image: ImgPtr; harrisResponce: ImgPtr; blockSize: cint;
                    apertureSize: cint = 3; k: cdouble = 4.0000000000000001e-02) {.
     cdecl, importc: "cvCornerHarris", dynlib: imgprocdll.}
-# Adjust corner position using some sort of gradient search 
+# Adjust corner position using some sort of gradient search
 
-proc findCornerSubPix*(image: ptr TArr; corners: ptr TPoint2D32f; count: cint; 
+proc findCornerSubPix*(image: ImgPtr; corners: ptr TPoint2D32f; count: cint;
                        win: TSize; zeroZone: TSize; criteria: TTermCriteria) {.
     cdecl, importc: "cvFindCornerSubPix", dynlib: imgprocdll.}
 # Finds a sparse set of points within the selected region
-#   that seem to be easy to track 
+#   that seem to be easy to track
 
-proc goodFeaturesToTrack*(image: ptr TArr; eigImage: ptr TArr; 
-                          tempImage: ptr TArr; corners: ptr TPoint2D32f; 
-                          cornerCount: ptr cint; qualityLevel: cdouble; 
-                          minDistance: cdouble; mask: ptr TArr = nil; 
-                          blockSize: cint = 3; useHarris: cint = 0; 
-                          k: cdouble = 4.0000000000000001e-02) {.cdecl, 
+proc goodFeaturesToTrack*(image: ImgPtr; eigImage: ImgPtr;
+                          tempImage: ImgPtr; corners: ptr TPoint2D32f;
+                          cornerCount: ptr cint; qualityLevel: cdouble;
+                          minDistance: cdouble; mask: ImgPtr = nil;
+                          blockSize: cint = 3; useHarris: cint = 0;
+                          k: cdouble = 4.0000000000000001e-02) {.cdecl,
     importc: "cvGoodFeaturesToTrack", dynlib: imgprocdll.}
 # Finds lines on binary image using one of several methods.
 #   line_storage is either memory storage or 1 x <max number of lines> CvMat, its
@@ -614,21 +615,21 @@ proc goodFeaturesToTrack*(image: ptr TArr; eigImage: ptr TArr;
 #   method is one of CV_HOUGH_*;
 #   rho, theta and threshold are used for each of those methods;
 #   param1 ~ line length, param2 ~ line gap - for probabilistic,
-#   param1 ~ srn, param2 ~ stn - for multi-scale 
+#   param1 ~ srn, param2 ~ stn - for multi-scale
 
-proc houghLines2*(image: ptr TArr; lineStorage: pointer; theMethod: cint; 
-                  rho: cdouble; theta: cdouble; threshold: cint; 
-                  param1: cdouble = 0; param2: cdouble = 0): ptr TSeq {.cdecl, 
+proc houghLines2*(image: ImgPtr; lineStorage: pointer; theMethod: cint;
+                  rho: cdouble; theta: cdouble; threshold: cint;
+                  param1: cdouble = 0; param2: cdouble = 0): ptr TSeq {.cdecl,
     importc: "cvHoughLines2", dynlib: imgprocdll.}
-# Finds circles in the image 
+# Finds circles in the image
 
-proc houghCircles*(image: ptr TArr; circleStorage: pointer; theMethod: cint; 
-                   dp: cdouble; minDist: cdouble; param1: cdouble = 100; 
-                   param2: cdouble = 100; minRadius: cint = 0; 
-                   maxRadius: cint = 0): ptr TSeq {.cdecl, 
+proc houghCircles*(image: ImgPtr; circleStorage: pointer; theMethod: cint;
+                   dp: cdouble; minDist: cdouble; param1: cdouble = 100;
+                   param2: cdouble = 100; minRadius: cint = 0;
+                   maxRadius: cint = 0): ptr TSeq {.cdecl,
     importc: "cvHoughCircles", dynlib: imgprocdll.}
-# Fits a line into set of 2d or 3d points in a robust way (M-estimator technique) 
+# Fits a line into set of 2d or 3d points in a robust way (M-estimator technique)
 
-proc fitLine*(points: ptr TArr; distType: cint; param: cdouble; reps: cdouble; 
-              aeps: cdouble; line: ptr cfloat) {.cdecl, importc: "cvFitLine", 
+proc fitLine*(points: ImgPtr; distType: cint; param: cdouble; reps: cdouble;
+              aeps: cdouble; line: ptr cfloat) {.cdecl, importc: "cvFitLine",
     dynlib: imgprocdll.}

--- a/opencv/imgproc/iptypes.nim
+++ b/opencv/imgproc/iptypes.nim
@@ -42,40 +42,40 @@
 
 {.deadCodeElim: on.}
 import opencv/core
-# Connected component structure 
+# Connected component structure
 
-type 
-  TConnectedComp* {.pure, final.} = object 
-    area*: cdouble            # area of the connected component  
-    value*: TScalar            # average color of the connected component 
-    rect*: TRect               # ROI of the component  
+type
+  TConnectedComp* {.pure, final.} = object
+    area*: cdouble            # area of the connected component
+    value*: TScalar            # average color of the connected component
+    rect*: TRect               # ROI of the component
     contour*: pointer         # optional component boundary
                               #                      (the contour might have child contours corresponding to the holes)
   TContourScanner* {.pure, final.} = object
 
-# Image smooth methods 
+# Image smooth methods
 
-const 
+const
   BLUR_NO_SCALE* = 0
   BLUR* = 1
   GAUSSIAN* = 2
   MEDIAN* = 3
   BILATERAL* = 4
 
-# Filters used in pyramid decomposition 
+# Filters used in pyramid decomposition
 
-const 
+const
   GAUSSIAN_5x5* = 7
 
-# Special filters 
+# Special filters
 
-const 
+const
   SCHARR* = - 1
   MAX_SOBEL_KSIZE* = 7
 
-# Constants for color conversion 
+# Constants for color conversion
 
-const 
+const
   BGR2BGRA* = 0
   RGB2RGBA* = BGR2BGRA
   BGRA2BGR* = 1
@@ -269,32 +269,32 @@ const
   BGRA2YUV_YV12* = 134
   COLORCVT_MAX* = 135
 
-# Sub-pixel interpolation methods 
+# Sub-pixel interpolation methods
 
-const 
+const
   INTER_NN* = 0
   INTER_LINEAR* = 1
   INTER_CUBIC* = 2
   INTER_AREA* = 3
   INTER_LANCZOS4* = 4
 
-# ... and other image warping flags 
+# ... and other image warping flags
 
-const 
+const
   WARP_FILL_OUTLIERS* = 8
   WARP_INVERSE_MAP* = 16
 
-# Shapes of a structuring element for morphological operations 
+# Shapes of a structuring element for morphological operations
 
-const 
+const
   SHAPE_RECT* = 0
   SHAPE_CROSS* = 1
   SHAPE_ELLIPSE* = 2
   SHAPE_CUSTOM* = 100
 
-# Morphological operations 
+# Morphological operations
 
-const 
+const
   MOP_ERODE* = 0
   MOP_DILATE* = 1
   MOP_OPEN* = 2
@@ -303,10 +303,10 @@ const
   MOP_TOPHAT* = 5
   MOP_BLACKHAT* = 6
 
-# Spatial and central moments 
+# Spatial and central moments
 
-type 
-  TMoments* {.pure, final.} = object 
+type
+  TMoments* {.pure, final.} = object
     m00*: cdouble
     m10*: cdouble
     m01*: cdouble
@@ -316,33 +316,33 @@ type
     m30*: cdouble
     m21*: cdouble
     m12*: cdouble
-    m03*: cdouble             # spatial moments 
+    m03*: cdouble             # spatial moments
     mu20*: cdouble
     mu11*: cdouble
     mu02*: cdouble
     mu30*: cdouble
     mu21*: cdouble
     mu12*: cdouble
-    mu03*: cdouble            # central moments 
-    inv_sqrt_m00*: cdouble    # m00 != 0 ? 1/sqrt(m00) : 0 
-  
+    mu03*: cdouble            # central moments
+    inv_sqrt_m00*: cdouble    # m00 != 0 ? 1/sqrt(m00) : 0
 
-# Hu invariants 
 
-type 
-  THuMoments* {.pure, final.} = object 
+# Hu invariants
+
+type
+  THuMoments* {.pure, final.} = object
     hu1*: cdouble
     hu2*: cdouble
     hu3*: cdouble
     hu4*: cdouble
     hu5*: cdouble
     hu6*: cdouble
-    hu7*: cdouble             # Hu invariants 
-  
+    hu7*: cdouble             # Hu invariants
 
-# Template matching methods 
 
-const 
+# Template matching methods
+
+const
   TM_SQDIFF* = 0
   TM_SQDIFF_NORMED* = 1
   TM_CCORR* = 2
@@ -350,22 +350,22 @@ const
   TM_CCOEFF* = 4
   TM_CCOEFF_NORMED* = 5
 
-type 
+type
   TDistanceFunction* = proc (a: ptr cfloat; b: ptr cfloat; user_param: pointer): cfloat {.
       cdecl, cdecl.}
 
-# Contour retrieval modes 
+# Contour retrieval modes
 
-const 
+const
   RETR_EXTERNAL* = 0
   RETR_LIST* = 1
   RETR_CCOMP* = 2
   RETR_TREE* = 3
   RETR_FLOODFILL* = 4
 
-# Contour approximation methods 
+# Contour approximation methods
 
-const 
+const
   CHAIN_CODE* = 0
   CHAIN_APPROX_NONE* = 1
   CHAIN_APPROX_SIMPLE* = 2
@@ -378,168 +378,168 @@ const
 #It supports both hierarchical and plane variants of Suzuki algorithm.
 #
 
-type 
+type
   PContourScanner* = pointer
 
-# Freeman chain reader state 
+# Freeman chain reader state
 
-type 
-  TChainPtReader* {.pure, final.} = object 
+type
+  TChainPtReader* {.pure, final.} = object
     code*: char               #CV_SEQ_READER_FIELDS()
     pt*: TPoint
     deltas*: array[0..2 - 1, array[0..8 - 1, Schar]]
 
 
-# initializes 8-element array for fast access to 3x3 neighborhood of a pixel 
+# initializes 8-element array for fast access to 3x3 neighborhood of a pixel
 
 #***************************************************************************************\
 #                              Planar subdivisions                                       *
 #\***************************************************************************************
 
-type 
+type
   TSubdiv2DEdge* = csize
 
-const 
+const
   SUBDIV2D_VIRTUAL_POINT_FLAG* = (1 shl 30)
 
-type 
-  TQuadEdge2D* {.pure, final.} = object 
+type
+  TQuadEdge2D* {.pure, final.} = object
     flags*: cint
     pt*: array[0..4 - 1, ptr TSubdiv2DPoint]
     next*: array[0..4 - 1, TSubdiv2DEdge]
 
-  TSubdiv2DPoint* {.pure, final.} = object 
+  TSubdiv2DPoint* {.pure, final.} = object
     flags*: cint
     first*: TSubdiv2DEdge
     pt*: TPoint2D32f
     id*: cint
 
-  TSubdiv2D* {.pure, final.} = object 
+  TSubdiv2D* {.pure, final.} = object
     quad_edges*: cint         #CV_GRAPH_FIELDS()
     is_geometry_valid*: cint
     recent_edge*: TSubdiv2DEdge
     topleft*: TPoint2D32f
     bottomright*: TPoint2D32f
 
-  TSubdiv2DPointLocation* {.size: sizeof(cint).} = enum 
-    PTLOC_ERROR = - 2, PTLOC_OUTSIDE_RECT = - 1, PTLOC_INSIDE = 0, 
+  TSubdiv2DPointLocation* {.size: sizeof(cint).} = enum
+    PTLOC_ERROR = - 2, PTLOC_OUTSIDE_RECT = - 1, PTLOC_INSIDE = 0,
     PTLOC_VERTEX = 1, PTLOC_ON_EDGE = 2
-discard """ TNextEdgeType* {.size: sizeof(cint).} = enum 
-  NEXT_AROUND_ORG = 0x00000000, NEXT_AROUND_DST = 0x00000022, 
-  PREV_AROUND_ORG = 0x00000011, PREV_AROUND_DST = 0x00000033, 
-  NEXT_AROUND_LEFT = 0x00000013, NEXT_AROUND_RIGHT = 0x00000031, 
+discard """ TNextEdgeType* {.size: sizeof(cint).} = enum
+  NEXT_AROUND_ORG = 0x00000000, NEXT_AROUND_DST = 0x00000022,
+  PREV_AROUND_ORG = 0x00000011, PREV_AROUND_DST = 0x00000033,
+  NEXT_AROUND_LEFT = 0x00000013, NEXT_AROUND_RIGHT = 0x00000031,
   PREV_AROUND_LEFT = 0x00000020, PREV_AROUND_RIGHT = 0x00000002 """
 
-# get the next edge with the same origin point (counterwise) 
+# get the next edge with the same origin point (counterwise)
 
-discard """ template SUBDIV2D_NEXT_EDGE*(edge: expr): expr = 
+discard """ template SUBDIV2D_NEXT_EDGE*(edge: untyped): untyped =
   cast[(cast[ptr TQuadEdge2D](((edge) and not 3)))](.next[(edge) and 3]) """
 
-# Contour approximation algorithms 
+# Contour approximation algorithms
 
-const 
+const
   POLY_APPROX_DP* = 0
 
-# Shape matching methods 
+# Shape matching methods
 
-const 
+const
   CONTOURS_MATCH_I1* = 1
   CONTOURS_MATCH_I2* = 2
   CONTOURS_MATCH_I3* = 3
 
-# Shape orientation 
+# Shape orientation
 
-const 
+const
   CLOCKWISE* = 1
   COUNTER_CLOCKWISE* = 2
 
-# Convexity defect 
+# Convexity defect
 
-type 
-  TConvexityDefect* {.pure, final.} = object 
-    start*: ptr TPoint         # point of the contour where the defect begins 
-    theEnd*: ptr TPoint        # point of the contour where the defect ends 
-    depth_point*: ptr TPoint   # the farthest from the convex hull point within the defect 
-    depth*: cfloat            # distance between the farthest point and the convex hull 
-  
+type
+  TConvexityDefect* {.pure, final.} = object
+    start*: ptr TPoint         # point of the contour where the defect begins
+    theEnd*: ptr TPoint        # point of the contour where the defect ends
+    depth_point*: ptr TPoint   # the farthest from the convex hull point within the defect
+    depth*: cfloat            # distance between the farthest point and the convex hull
 
-# Histogram comparison methods 
 
-const 
+# Histogram comparison methods
+
+const
   COMP_CORREL* = 0
   COMP_CHISQR* = 1
   COMP_INTERSECT* = 2
   COMP_BHATTACHARYYA* = 3
   COMP_HELLINGER* = COMP_BHATTACHARYYA
 
-# Mask size for distance transform 
+# Mask size for distance transform
 
-const 
+const
   DIST_MASK_3* = 3
   DIST_MASK_5* = 5
   DIST_MASK_PRECISE* = 0
 
-# Content of output label array: connected components or pixels 
+# Content of output label array: connected components or pixels
 
-const 
+const
   DIST_LABEL_CCOMP* = 0
   DIST_LABEL_PIXEL* = 1
 
-# Distance types for Distance Transform and M-estimators 
+# Distance types for Distance Transform and M-estimators
 
-const 
-  DIST_USER* = - 1            # User defined distance 
-  DIST_L1* = 1                # distance = |x1-x2| + |y1-y2| 
-  DIST_L2* = 2                # the simple euclidean distance 
-  DIST_C* = 3                 # distance = max(|x1-x2|,|y1-y2|) 
-  DIST_L12* = 4               # L1-L2 metric: distance = 2(sqrt(1+x*x/2) - 1)) 
-  DIST_FAIR* = 5              # distance = c^2(|x|/c-log(1+|x|/c)), c = 1.3998 
-  DIST_WELSCH* = 6            # distance = c^2/2(1-exp(-(x/c)^2)), c = 2.9846 
-  DIST_HUBER* = 7             # distance = |x|<c ? x^2/2 : c(|x|-c/2), c=1.345 
+const
+  DIST_USER* = - 1            # User defined distance
+  DIST_L1* = 1                # distance = |x1-x2| + |y1-y2|
+  DIST_L2* = 2                # the simple euclidean distance
+  DIST_C* = 3                 # distance = max(|x1-x2|,|y1-y2|)
+  DIST_L12* = 4               # L1-L2 metric: distance = 2(sqrt(1+x*x/2) - 1))
+  DIST_FAIR* = 5              # distance = c^2(|x|/c-log(1+|x|/c)), c = 1.3998
+  DIST_WELSCH* = 6            # distance = c^2/2(1-exp(-(x/c)^2)), c = 2.9846
+  DIST_HUBER* = 7             # distance = |x|<c ? x^2/2 : c(|x|-c/2), c=1.345
 
-# Threshold types 
+# Threshold types
 
-const 
-  THRESH_BINARY* = 0          # value = value > threshold ? max_value : 0       
-  THRESH_BINARY_INV* = 1      # value = value > threshold ? 0 : max_value       
-  THRESH_TRUNC* = 2           # value = value > threshold ? threshold : value   
-  THRESH_TOZERO* = 3          # value = value > threshold ? value : 0           
-  THRESH_TOZERO_INV* = 4      # value = value > threshold ? 0 : value           
+const
+  THRESH_BINARY* = 0          # value = value > threshold ? max_value : 0
+  THRESH_BINARY_INV* = 1      # value = value > threshold ? 0 : max_value
+  THRESH_TRUNC* = 2           # value = value > threshold ? threshold : value
+  THRESH_TOZERO* = 3          # value = value > threshold ? value : 0
+  THRESH_TOZERO_INV* = 4      # value = value > threshold ? 0 : value
   THRESH_MASK* = 7
   THRESH_OTSU* = 8 # use Otsu algorithm to choose the optimal threshold value;
-                   #                                 combine the flag with one of the above CV_THRESH_* values 
+                   #                                 combine the flag with one of the above CV_THRESH_* values
 
-# Adaptive threshold methods 
+# Adaptive threshold methods
 
-const 
+const
   ADAPTIVE_THRESH_MEAN_C* = 0
   ADAPTIVE_THRESH_GAUSSIAN_C* = 1
 
-# FloodFill flags 
+# FloodFill flags
 
-const 
+const
   FLOODFILL_FIXED_RANGE* = (1 shl 16)
   FLOODFILL_MASK_ONLY* = (1 shl 17)
 
-# Canny edge detector flags 
+# Canny edge detector flags
 
-const 
+const
   CANNY_L2_GRADIENT* = (1 shl 31)
 
-# Variants of a Hough transform 
+# Variants of a Hough transform
 
-const 
+const
   HOUGH_STANDARD* = 0
   HOUGH_PROBABILISTIC* = 1
   HOUGH_MULTI_SCALE* = 2
   HOUGH_GRADIENT* = 3
 
-# Fast search data structures  
+# Fast search data structures
 
-type 
-  TFeatureTree* {.pure, final.} = object 
-  
-  TLSH* {.pure, final.} = object 
-  
-  TLSHOperations* {.pure, final.} = object 
-  
+type
+  TFeatureTree* {.pure, final.} = object
+
+  TLSH* {.pure, final.} = object
+
+  TLSHOperations* {.pure, final.} = object
+

--- a/opencv/types.nim
+++ b/opencv/types.nim
@@ -287,7 +287,7 @@ type
     rows*: cint
     cols*: cint
 
-  MatPtr* = ptr TMat*
+  MatPtr* = ptr TMat
 
 #***************************************************************************************\
 #                       Multi-dimensional dense array (CvMatND)                          *
@@ -315,7 +315,7 @@ type
     data*: TMatNDdata
     dim*: array[0..MAX_DIM - 1, TMatNDDim]
 
-  MatNDPtr* = ptr TMapND
+  MatNDPtr* = ptr TMatND
 
 #***************************************************************************************\
 #                      Multi-dimensional sparse array (CvSparseMat)                      *

--- a/opencv/types.nim
+++ b/opencv/types.nim
@@ -42,7 +42,7 @@
 
 from math import round
 
-type 
+type
 
   Schar* = cchar
 
@@ -50,13 +50,13 @@ type
 #  array-like data structures
 #  into functions where the particular
 #  array type is recognized at runtime:
-# 
+#
 
 type
-  T32suf* {.pure, final.} = object 
+  T32suf* {.pure, final.} = object
     i*: cint
 
-  T64suf* {.pure, final.} = object 
+  T64suf* {.pure, final.} = object
     i*: int64
 
   TStatus* = cint
@@ -65,7 +65,7 @@ type
 #                                  Image type (IplImage)                                 *
 #\***************************************************************************************
 
-const 
+const
   IPL_DEPTH_SIGN* = 0x80000000
   IPL_DEPTH_1U* = 1
   IPL_DEPTH_8U* = 8
@@ -89,49 +89,49 @@ const
   IPL_BORDER_REFLECT* = 2
   IPL_BORDER_WRAP* = 3
 
-type 
-  TIplImage* {.pure, final.} = object 
-    nSize*: cint              # sizeof(IplImage) 
+type
+  TIplImage* {.pure, final.} = object
+    nSize*: cint              # sizeof(IplImage)
     id*: cint                 # version (=0)
-    nChannels*: cint          # Most of OpenCV functions support 1,2,3 or 4 channels 
-    alphaChannel*: cint       # Ignored by OpenCV 
+    nChannels*: cint          # Most of OpenCV functions support 1,2,3 or 4 channels
+    alphaChannel*: cint       # Ignored by OpenCV
     depth*: cint # Pixel depth in bits: IPL_DEPTH_8U, IPL_DEPTH_8S, IPL_DEPTH_16S,
-                 #                               IPL_DEPTH_32S, IPL_DEPTH_32F and IPL_DEPTH_64F are supported.  
-    colorModel*: array[0..4 - 1, char] # Ignored by OpenCV 
-    channelSeq*: array[0..4 - 1, char] # ditto 
+                 #                               IPL_DEPTH_32S, IPL_DEPTH_32F and IPL_DEPTH_64F are supported.
+    colorModel*: array[0..4 - 1, char] # Ignored by OpenCV
+    channelSeq*: array[0..4 - 1, char] # ditto
     dataOrder*: cint # 0 - interleaved color channels, 1 - separate color channels.
-                     #                               cvCreateImage can only create interleaved images 
+                     #                               cvCreateImage can only create interleaved images
     origin*: cint             # 0 - top-left origin,
-                              #                               1 - bottom-left origin (Windows bitmaps style).  
+                              #                               1 - bottom-left origin (Windows bitmaps style).
     align*: cint              # Alignment of image rows (4 or 8).
-                              #                               OpenCV ignores it and uses widthStep instead.    
-    width*: cint              # Image width in pixels.                           
-    height*: cint             # Image height in pixels.                          
-    roi*: ptr TIplROI          # Image ROI. If NULL, the whole image is selected. 
-    maskROI*: ptr TIplImage    # Must be NULL. 
-    imageId*: pointer         # "           " 
-    tileInfo*: ptr TIplTileInfo # "           " 
+                              #                               OpenCV ignores it and uses widthStep instead.
+    width*: cint              # Image width in pixels.
+    height*: cint             # Image height in pixels.
+    roi*: ptr TIplROI          # Image ROI. If NULL, the whole image is selected.
+    maskROI*: ptr TIplImage    # Must be NULL.
+    imageId*: pointer         # "           "
+    tileInfo*: ptr TIplTileInfo # "           "
     imageSize*: cint # Image data size in bytes
                      #                               (==image->height*image->widthStep
                      #                               in case of interleaved data)
-    imageData*: cstring       # Pointer to aligned image data.         
-    widthStep*: cint          # Size of aligned image row in bytes.    
-    borderMode*: array[0..4 - 1, cint] # Ignored by OpenCV.                     
-    borderConst*: array[0..4 - 1, cint] # Ditto.                                 
+    imageData*: cstring       # Pointer to aligned image data.
+    widthStep*: cint          # Size of aligned image row in bytes.
+    borderMode*: array[0..4 - 1, cint] # Ignored by OpenCV.
+    borderConst*: array[0..4 - 1, cint] # Ditto.
     imageDataOrigin*: cstring # Pointer to very origin of image data
                               #                               (not necessarily aligned) -
-                              #                               needed for correct deallocation 
-  
-  TIplTileInfo* {.pure, final.} = object 
-  
-  TIplROI* {.pure, final.} = object 
+                              #                               needed for correct deallocation
+
+  TIplTileInfo* {.pure, final.} = object
+
+  TIplROI* {.pure, final.} = object
     coi*: cint                # 0 - no COI (all channels are selected), 1 - 0th channel is selected ...
     xOffset*: cint
     yOffset*: cint
     width*: cint
     height*: cint
 
-  TIplConvKernel* {.pure, final.} = object 
+  TIplConvKernel* {.pure, final.} = object
     nCols*: cint
     nRows*: cint
     anchorX*: cint
@@ -139,20 +139,21 @@ type
     values*: ptr cint
     nShiftR*: cint
 
-  TIplConvKernelFP* {.pure, final.} = object 
+  TIplConvKernelFP* {.pure, final.} = object
     nCols*: cint
     nRows*: cint
     anchorX*: cint
     anchorY*: cint
     values*: ptr cfloat
-  
+
   TArr* = TIplImage
+  ImgPtr* = ptr TArr
 
 #***************************************************************************************\
 #                                  Matrix type (CvMat)                                   *
 #\***************************************************************************************
 
-const 
+const
   CN_MAX* = 512
   CN_SHIFT* = 3
   DEPTH_MAX* = (1 shl CN_SHIFT)
@@ -166,146 +167,147 @@ const
   USRTYPE1* = 7
   MAT_DEPTH_MASK* = (DEPTH_MAX - 1)
 
-template Mat_Depth*(flags: expr): expr = 
+template Mat_Depth*(flags: untyped): untyped =
   ((flags) and MAT_DEPTH_MASK)
 
-template maketype*(depth, cn: expr): expr = 
+template maketype*(depth, cn: untyped): untyped =
   (MAT_DEPTH(depth) + (((cn) - 1) shl CN_SHIFT))
 
-const 
+const
   CV_8UC1* = maketype(CV_8U, 1)
   CV_8UC2* = maketype(CV_8U, 2)
   CV_8UC3* = maketype(CV_8U, 3)
   CV_8UC4* = maketype(CV_8U, 4)
 
-template Cv_8uc*(n: expr): expr = 
+template Cv_8uc*(n: untyped): untyped =
   MAKETYPE(CV_8U, (n))
 
-const 
+const
   CV_8SC1* = maketype(CV_8S, 1)
   CV_8SC2* = maketype(CV_8S, 2)
   CV_8SC3* = maketype(CV_8S, 3)
   CV_8SC4* = maketype(CV_8S, 4)
 
-template Cv_8sc*(n: expr): expr = 
+template Cv_8sc*(n: untyped): untyped =
   MAKETYPE(CV_8S, (n))
 
-const 
+const
   CV_16UC1* = maketype(CV_16U, 1)
   CV_16UC2* = maketype(CV_16U, 2)
   CV_16UC3* = maketype(CV_16U, 3)
   CV_16UC4* = maketype(CV_16U, 4)
 
-template Cv_16uc*(n: expr): expr = 
+template Cv_16uc*(n: untyped): untyped =
   MAKETYPE(CV_16U, (n))
 
-const 
+const
   CV_16SC1* = maketype(CV_16S, 1)
   CV_16SC2* = maketype(CV_16S, 2)
   CV_16SC3* = maketype(CV_16S, 3)
   CV_16SC4* = maketype(CV_16S, 4)
 
-template Cv_16sc*(n: expr): expr = 
+template Cv_16sc*(n: untyped): untyped =
   MAKETYPE(CV_16S, (n))
 
-const 
+const
   CV_32SC1* = maketype(CV_32S, 1)
   CV_32SC2* = maketype(CV_32S, 2)
   CV_32SC3* = maketype(CV_32S, 3)
   CV_32SC4* = maketype(CV_32S, 4)
 
-template Cv_32sc*(n: expr): expr = 
+template Cv_32sc*(n: untyped): untyped =
   MAKETYPE(CV_32S, (n))
 
-const 
+const
   CV_32FC1* = maketype(CV_32F, 1)
   CV_32FC2* = maketype(CV_32F, 2)
   CV_32FC3* = maketype(CV_32F, 3)
   CV_32FC4* = maketype(CV_32F, 4)
 
-template Cv_32fc*(n: expr): expr = 
+template Cv_32fc*(n: untyped): untyped =
   MAKETYPE(CV_32F, (n))
 
-const 
+const
   CV_64FC1* = maketype(CV_64F, 1)
   CV_64FC2* = maketype(CV_64F, 2)
   CV_64FC3* = maketype(CV_64F, 3)
   CV_64FC4* = maketype(CV_64F, 4)
 
-template Cv_64fc*(n: expr): expr = 
+template Cv_64fc*(n: untyped): untyped =
   MAKETYPE(CV_64F, (n))
 
-template Whole_Arr*(): expr =
+template Whole_Arr*(): untyped =
   Slice(0, 0x3FFFFFFF)
 
-const 
+const
   AUTO_STEP* = 0x7FFFFFFF
   MAT_CN_MASK* = ((CN_MAX - 1) shl CN_SHIFT)
 
-template Mat_Cn*(flags: expr): expr = 
+template Mat_Cn*(flags: untyped): untyped =
   ((((flags) and MAT_CN_MASK) shr CN_SHIFT) + 1)
 
-const 
+const
   MAT_TYPE_MASK* = (DEPTH_MAX * CN_MAX - 1)
 
-template Mat_Type*(flags: expr): expr = 
+template Mat_Type*(flags: untyped): untyped =
   ((flags) and MAT_TYPE_MASK)
 
-const 
+const
   MAT_CONT_FLAG_SHIFT* = 14
   MAT_CONT_FLAG* = (1 shl MAT_CONT_FLAG_SHIFT)
 
-template Is_Mat_Cont*(flags: expr): expr = 
+template Is_Mat_Cont*(flags: untyped): untyped =
   ((flags) and MAT_CONT_FLAG)
 
-template Is_Cont_Mat*(flags: expr): expr =
+template Is_Cont_Mat*(flags: untyped): untyped =
   IS_MAT_CONT(flags)
 
 const
   SUBMAT_FLAG_SHIFT* = 15
   SUBMAT_FLAG* = (1 shl SUBMAT_FLAG_SHIFT)
 
-template Is_Submat*(flags: expr): expr = 
+template Is_Submat*(flags: untyped): untyped =
   ((flags) and MAT_SUBMAT_FLAG)
 
-const 
+const
   MAGIC_MASK* = 0xFFFF0000
   MAT_MAGIC_VAL* = 0x42420000
   TYPE_NAME_MAT* = "opencv-matrix"
 
-type 
-  TMatData* {.pure, final.} = object 
+type
+  TMatData* {.pure, final.} = object
     thePtr*: ptr cuchar
 
-  TMat* {.pure, final.} = object 
+  TMat* {.pure, final.} = object
     theType*: cint
-    step*: cint               # for internal use only 
+    step*: cint               # for internal use only
     refcount*: ptr cint
     hdrRefcount*: cint
     data*: TMatData
     rows*: cint
     cols*: cint
 
+  MatPtr* = ptr TMat*
 
 #***************************************************************************************\
 #                       Multi-dimensional dense array (CvMatND)                          *
 #\***************************************************************************************
 
-const 
+const
   MATND_MAGIC_VAL* = 0x42430000
   TYPE_NAME_MATND* = "opencv-nd-matrix"
   MAX_DIM* = 32
   MAX_DIM_HEAP* = 1024
 
-type 
-  TMatNDdata* {.pure, final.} = object 
+type
+  TMatNDdata* {.pure, final.} = object
     thePtr*: ptr cuchar
 
-  TMatNDDim* {.pure, final.} = object 
+  TMatNDDim* {.pure, final.} = object
     size*: cint
     step*: cint
 
-  TMatND* {.pure, final.} = object 
+  TMatND* {.pure, final.} = object
     theType*: cint
     dims*: cint
     refcount*: ptr cint
@@ -313,19 +315,20 @@ type
     data*: TMatNDdata
     dim*: array[0..MAX_DIM - 1, TMatNDDim]
 
+  MatNDPtr* = ptr TMapND
 
 #***************************************************************************************\
 #                      Multi-dimensional sparse array (CvSparseMat)                      *
 #\***************************************************************************************
 
-const 
+const
   SPARSE_MAT_MAGIC_VAL* = 0x42440000
   TYPE_NAME_SPARSE_MAT* = "opencv-sparse-matrix"
 
-type 
-  TSet* {.pure, final.} = object 
-  
-  TSparseMat* {.pure, final.} = object 
+type
+  TSet* {.pure, final.} = object
+
+  TSparseMat* {.pure, final.} = object
     theType*: cint
     dims*: cint
     refcount*: ptr cint
@@ -340,12 +343,12 @@ type
 
 #*************** iteration through a sparse array ****************
 
-type 
-  TSparseNode* {.pure, final.} = object 
+type
+  TSparseNode* {.pure, final.} = object
     hashval*: cuint
     next*: ptr TSparseNode
 
-  TSparseMatIterator* {.pure, final.} = object 
+  TSparseMatIterator* {.pure, final.} = object
     mat*: ptr TSparseMat
     node*: ptr TSparseNode
     curidx*: cint
@@ -354,50 +357,50 @@ type
 #                                         Histogram                                      *
 #\***************************************************************************************
 
-type 
+type
   THistType* = cint
 
-const 
+const
   HIST_MAGIC_VAL* = 0x42450000
   HIST_UNIFORM_FLAG* = (1 shl 10)
 
-# indicates whether bin ranges are set already or not 
+# indicates whether bin ranges are set already or not
 
-const 
+const
   HIST_RANGES_FLAG* = (1 shl 11)
   HIST_ARRAY* = 0
   HIST_SPARSE* = 1
   HIST_TREE* = HIST_SPARSE
 
 # should be used as a parameter only,
-#   it turns to CV_HIST_UNIFORM_FLAG of hist->type 
+#   it turns to CV_HIST_UNIFORM_FLAG of hist->type
 
-const 
+const
   HIST_UNIFORM* = 1
 
-type 
-  THistogram* {.pure, final.} = object 
+type
+  THistogram* {.pure, final.} = object
     theType*: cint
     bins*: ptr TArr
-    thresh*: array[0..2 - 1, array[0..MAX_DIM - 1, cfloat]] # For uniform histograms.                      
-    thresh2*: ptr ptr cfloat  # For non-uniform histograms.                  
-    mat*: TMatND              # Embedded matrix header for array histograms. 
-  
+    thresh*: array[0..2 - 1, array[0..MAX_DIM - 1, cfloat]] # For uniform histograms.
+    thresh2*: ptr ptr cfloat  # For non-uniform histograms.
+    mat*: TMatND              # Embedded matrix header for array histograms.
+
 
 #***************************************************************************************\
 #                      Other supplementary data type definitions                         *
 #\***************************************************************************************
 #************************************** CvRect ****************************************
 
-type 
-  TRect* {.pure, final.} = object 
+type
+  TRect* {.pure, final.} = object
     x*: cint
     y*: cint
     width*: cint
     height*: cint
 
 
-proc rect*(x: cint; y: cint; width: cint; height: cint): TRect {.cdecl.} = 
+proc rect*(x: cint; y: cint; width: cint; height: cint): TRect {.cdecl.} =
   var r: TRect
   r.x = x
   r.y = y
@@ -405,7 +408,7 @@ proc rect*(x: cint; y: cint; width: cint; height: cint): TRect {.cdecl.} =
   r.height = height
   return r
 
-proc rectToROI*(rect: TRect; coi: cint): TIplROI {.cdecl.} = 
+proc rectToROI*(rect: TRect; coi: cint): TIplROI {.cdecl.} =
   var roi: TIplROI
   roi.xOffset = rect.x
   roi.yOffset = rect.y
@@ -414,27 +417,27 @@ proc rectToROI*(rect: TRect; coi: cint): TIplROI {.cdecl.} =
   roi.coi = coi
   return roi
 
-proc rOIToRect*(roi: TIplROI): TRect {.cdecl.} = 
+proc rOIToRect*(roi: TIplROI): TRect {.cdecl.} =
   return rect(roi.xOffset, roi.yOffset, roi.width, roi.height)
 
 #********************************** CvTermCriteria ************************************
 
-const 
+const
   TERMCRIT_ITER* = 1
   TERMCRIT_NUMBER* = TERMCRIT_ITER
   TERMCRIT_EPS* = 2
 
-type 
-  TTermCriteria* {.pure, final.} = object 
+type
+  TTermCriteria* {.pure, final.} = object
     theType*: cint            # may be combination of
                               #                     CV_TERMCRIT_ITER
-                              #                     CV_TERMCRIT_EPS 
+                              #                     CV_TERMCRIT_EPS
     maxIter*: cint
     epsilon*: cdouble
 
 
 proc termCriteria*(theType: cint; maxIter: cint; epsilon: cdouble): TTermCriteria {.
-    cdecl.} = 
+    cdecl.} =
   var t: TTermCriteria
   t.theType = theType
   t.maxIter = maxIter
@@ -443,73 +446,73 @@ proc termCriteria*(theType: cint; maxIter: cint; epsilon: cdouble): TTermCriteri
 
 #****************************** CvPoint and variants **********************************
 
-type 
-  TPoint* {.pure, final.} = object 
+type
+  TPoint* {.pure, final.} = object
     x*: cint
     y*: cint
 
 
-proc point*(x: cint; y: cint): TPoint {.cdecl.} = 
+proc point*(x: cint; y: cint): TPoint {.cdecl.} =
   var p: TPoint
   p.x = x
   p.y = y
   return p
 
-type 
-  TPoint2D32f* {.pure, final.} = object 
+type
+  TPoint2D32f* {.pure, final.} = object
     x*: cfloat
     y*: cfloat
 
 
-proc point2D32f*(x: cdouble; y: cdouble): TPoint2D32f {.cdecl.} = 
+proc point2D32f*(x: cdouble; y: cdouble): TPoint2D32f {.cdecl.} =
   var p: TPoint2D32f
   p.x = cast[cfloat](x)
   p.y = cast[cfloat](y)
   return p
 
-proc pointTo32f*(point: TPoint): TPoint2D32f {.cdecl.} = 
+proc pointTo32f*(point: TPoint): TPoint2D32f {.cdecl.} =
   return point2D32f(cast[cfloat](point.x), cast[cfloat](point.y))
 
-proc pointFrom32f*(point: TPoint2D32f): TPoint {.cdecl.} = 
+proc pointFrom32f*(point: TPoint2D32f): TPoint {.cdecl.} =
   var ipt: TPoint
   ipt.x = round(point.x).cint
   ipt.y = round(point.y).cint
   return ipt
 
-type 
-  TPoint3D32f* {.pure, final.} = object 
+type
+  TPoint3D32f* {.pure, final.} = object
     x*: cfloat
     y*: cfloat
     z*: cfloat
 
 
-proc point3D32f*(x: cdouble; y: cdouble; z: cdouble): TPoint3D32f {.cdecl.} = 
+proc point3D32f*(x: cdouble; y: cdouble; z: cdouble): TPoint3D32f {.cdecl.} =
   var p: TPoint3D32f
   p.x = cast[cfloat](x)
   p.y = cast[cfloat](y)
   p.z = cast[cfloat](z)
   return p
 
-type 
-  TPoint2D64f* {.pure, final.} = object 
+type
+  TPoint2D64f* {.pure, final.} = object
     x*: cdouble
     y*: cdouble
 
 
-proc point2D64f*(x: cdouble; y: cdouble): TPoint2D64f {.cdecl.} = 
+proc point2D64f*(x: cdouble; y: cdouble): TPoint2D64f {.cdecl.} =
   var p: TPoint2D64f
   p.x = x
   p.y = y
   return p
 
-type 
-  TPoint3D64f* {.pure, final.} = object 
+type
+  TPoint3D64f* {.pure, final.} = object
     x*: cdouble
     y*: cdouble
     z*: cdouble
 
 
-proc point3D64f*(x: cdouble; y: cdouble; z: cdouble): TPoint3D64f {.cdecl.} = 
+proc point3D64f*(x: cdouble; y: cdouble; z: cdouble): TPoint3D64f {.cdecl.} =
   var p: TPoint3D64f
   p.x = x
   p.y = y
@@ -518,44 +521,44 @@ proc point3D64f*(x: cdouble; y: cdouble; z: cdouble): TPoint3D64f {.cdecl.} =
 
 #******************************* CvSize's & CvBox *************************************
 
-type 
-  TSize* {.pure, final.} = object 
+type
+  TSize* {.pure, final.} = object
     width*: cint
     height*: cint
 
 
-proc size*(width: cint; height: cint): TSize {.cdecl.} = 
+proc size*(width: cint; height: cint): TSize {.cdecl.} =
   var s: TSize
   s.width = width
   s.height = height
   return s
 
-type 
-  TSize2D32f* {.pure, final.} = object 
+type
+  TSize2D32f* {.pure, final.} = object
     width*: cfloat
     height*: cfloat
 
 
-proc size2D32f*(width: cdouble; height: cdouble): TSize2D32f {.cdecl.} = 
+proc size2D32f*(width: cdouble; height: cdouble): TSize2D32f {.cdecl.} =
   var s: TSize2D32f
   s.width = cast[cfloat](width)
   s.height = cast[cfloat](height)
   return s
 
-type 
-  TBox2D* {.pure, final.} = object 
-    center*: TPoint2D32f      # Center of the box.                          
-    size*: TSize2D32f         # Box width and length.                       
-    angle*: cfloat            # Angle between the horizontal axis           
-                              # and the first side (i.e. length) in degrees 
-  
+type
+  TBox2D* {.pure, final.} = object
+    center*: TPoint2D32f      # Center of the box.
+    size*: TSize2D32f         # Box width and length.
+    angle*: cfloat            # Angle between the horizontal axis
+                              # and the first side (i.e. length) in degrees
 
-# Line iterator state: 
 
-type 
-  TLineIterator* {.pure, final.} = object 
+# Line iterator state:
+
+type
+  TLineIterator* {.pure, final.} = object
     thePtr*: ptr cuchar        # Pointer to the current point: \
-    # Bresenham algorithm state: 
+    # Bresenham algorithm state:
     err*: cint
     plusDelta*: cint
     minusDelta*: cint
@@ -565,32 +568,32 @@ type
 
 #************************************ CvSlice *****************************************
 
-type 
-  TSlice* {.pure, final.} = object 
+type
+  TSlice* {.pure, final.} = object
     startIndex*: cint
     endIndex*: cint
 
 
-proc slice*(start: cint; theEnd: cint): TSlice {.cdecl.} = 
+proc slice*(start: cint; theEnd: cint): TSlice {.cdecl.} =
   var slice: TSlice
   slice.startIndex = start
   slice.endIndex = theEnd
   return slice
 
-const 
+const
   WHOLE_SEQ_END_INDEX* = 0x3FFFFFFF
 
-template Whole_Seq*: expr = slice(0, WHOLE_SEQ_END_INDEX)
+template Whole_Seq*: untyped = slice(0, WHOLE_SEQ_END_INDEX)
 
 #************************************ CvScalar ****************************************
 
-type 
-  TScalar* {.pure, final.} = object 
+type
+  TScalar* {.pure, final.} = object
     val*: array[0..4 - 1, cdouble]
 
 
-proc scalar*(val0: cdouble; val1: cdouble = 0; val2: cdouble = 0; 
-               val3: cdouble = 0): TScalar {.cdecl.} = 
+proc scalar*(val0: cdouble; val1: cdouble = 0; val2: cdouble = 0;
+               val3: cdouble = 0): TScalar {.cdecl.} =
   var scalar: TScalar
   scalar.val[0] = val0
   scalar.val[1] = val1
@@ -598,7 +601,7 @@ proc scalar*(val0: cdouble; val1: cdouble = 0; val2: cdouble = 0;
   scalar.val[3] = val3
   return scalar
 
-proc realScalar*(val0: cdouble): TScalar {.cdecl.} = 
+proc realScalar*(val0: cdouble): TScalar {.cdecl.} =
   var scalar: TScalar
   scalar.val[0] = val0
   scalar.val[1] = 0
@@ -606,7 +609,7 @@ proc realScalar*(val0: cdouble): TScalar {.cdecl.} =
   scalar.val[3] = 0
   return scalar
 
-proc scalarAll*(val0123: cdouble): TScalar {.cdecl.} = 
+proc scalarAll*(val0123: cdouble): TScalar {.cdecl.} =
   var scalar: TScalar
   scalar.val[0] = val0123
   scalar.val[1] = val0123
@@ -619,62 +622,62 @@ proc scalarAll*(val0123: cdouble): TScalar {.cdecl.} =
 #\***************************************************************************************
 #******************************* Memory storage ***************************************
 
-type 
-  TMemBlock* {.pure, final.} = object 
+type
+  TMemBlock* {.pure, final.} = object
     prev*: ptr TMemBlock
     next*: ptr TMemBlock
 
 
-const 
+const
   STORAGE_MAGIC_VAL* = 0x42890000
 
-type 
-  TMemStorage* {.pure, final.} = object 
+type
+  TMemStorage* {.pure, final.} = object
     signature*: cint
-    bottom*: ptr TMemBlock    # First allocated block.                   
-    top*: ptr TMemBlock       # Current memory block - top of the stack. 
-    parent*: ptr TMemStorage  # We get new blocks from parent as needed. 
-    blockSize*: cint         # Block size.                              
-    freeSpace*: cint         # Remaining free space in current block.   
-  
-  TMemStoragePos* {.pure, final.} = object 
+    bottom*: ptr TMemBlock    # First allocated block.
+    top*: ptr TMemBlock       # Current memory block - top of the stack.
+    parent*: ptr TMemStorage  # We get new blocks from parent as needed.
+    blockSize*: cint         # Block size.
+    freeSpace*: cint         # Remaining free space in current block.
+
+  TMemStoragePos* {.pure, final.} = object
     top*: ptr TMemBlock
     freeSpace*: cint
 
 
 #********************************** Sequence ******************************************
 
-type 
-  TSeqBlock* {.pure, final.} = object 
-    prev*: ptr TSeqBlock      # Previous sequence block.                   
-    next*: ptr TSeqBlock      # Next sequence block.                       
-    startIndex*: cint        # Index of the first element in the block +  
-                              # sequence->first->start_index.              
-    count*: cint              # Number of elements in the block.           
-    data*: ptr Schar          # Pointer to the first element of the block. 
-  
+type
+  TSeqBlock* {.pure, final.} = object
+    prev*: ptr TSeqBlock      # Previous sequence block.
+    next*: ptr TSeqBlock      # Next sequence block.
+    startIndex*: cint        # Index of the first element in the block +
+                              # sequence->first->start_index.
+    count*: cint              # Number of elements in the block.
+    data*: ptr Schar          # Pointer to the first element of the block.
+
 
 #
 #   Read/Write sequence.
 #   Elements can be dynamically inserted to or deleted from the sequence.
 #
 
-type 
-  TSeq* {.pure, final.} = object 
-    flags*: cint              # Miscellaneous flags.     
-    headerSize*: cint        # Size of sequence header. 
-    vNext*: ptr TSeq         # 2nd next sequence.       
-    total*: cint              # Total number of elements.            
-    elemSize*: cint          # Size of sequence element in bytes.   
-    blockMax*: ptr Schar     # Maximal bound of the last block.     
-    thePtr*: ptr Schar        # Current write pointer.               
-    deltaElems*: cint        # Grow seq this many at a time.        
-    storage*: ptr TMemStorage # Where the seq is stored.             
-    freeBlocks*: ptr TSeqBlock # Free blocks list.                    
-    first*: ptr TSeqBlock     # Pointer to the first sequence block. 
-  
+type
+  TSeq* {.pure, final.} = object
+    flags*: cint              # Miscellaneous flags.
+    headerSize*: cint        # Size of sequence header.
+    vNext*: ptr TSeq         # 2nd next sequence.
+    total*: cint              # Total number of elements.
+    elemSize*: cint          # Size of sequence element in bytes.
+    blockMax*: ptr Schar     # Maximal bound of the last block.
+    thePtr*: ptr Schar        # Current write pointer.
+    deltaElems*: cint        # Grow seq this many at a time.
+    storage*: ptr TMemStorage # Where the seq is stored.
+    freeBlocks*: ptr TSeqBlock # Free blocks list.
+    first*: ptr TSeqBlock     # Pointer to the first sequence block.
 
-const 
+
+const
   TYPE_NAME_SEQ* = "opencv-sequence"
   TYPE_NAME_SEQ_TREE* = "opencv-sequence-tree"
 
@@ -686,32 +689,32 @@ const
 #  The MSB(most-significant or sign bit) of the first field (flags) is 0 iff the element exists.
 #
 
-type 
-  TSetElem* {.pure, final.} = object 
+type
+  TSetElem* {.pure, final.} = object
     flags*: cint
     nextFree*: ptr TSetElem
 
-  TCvSet* {.pure, final.} = object 
-    flags*: cint              # Miscellaneous flags.     
-    headerSize*: cint        # Size of sequence header. 
-    vNext*: ptr TSeq         # 2nd next sequence.       
-    total*: cint              # Total number of elements.            
-    elemSize*: cint          # Size of sequence element in bytes.   
-    blockMax*: ptr Schar     # Maximal bound of the last block.     
-    thePtr*: ptr Schar        # Current write pointer.               
-    deltaElems*: cint        # Grow seq this many at a time.        
-    storage*: ptr TMemStorage # Where the seq is stored.             
-    freeBlocks*: ptr TSeqBlock # Free blocks list.                    
-    first*: ptr TSeqBlock     # Pointer to the first sequence block. 
+  TCvSet* {.pure, final.} = object
+    flags*: cint              # Miscellaneous flags.
+    headerSize*: cint        # Size of sequence header.
+    vNext*: ptr TSeq         # 2nd next sequence.
+    total*: cint              # Total number of elements.
+    elemSize*: cint          # Size of sequence element in bytes.
+    blockMax*: ptr Schar     # Maximal bound of the last block.
+    thePtr*: ptr Schar        # Current write pointer.
+    deltaElems*: cint        # Grow seq this many at a time.
+    storage*: ptr TMemStorage # Where the seq is stored.
+    freeBlocks*: ptr TSeqBlock # Free blocks list.
+    first*: ptr TSeqBlock     # Pointer to the first sequence block.
     freeElems*: ptr TSetElem
     activeCount*: cint
 
 
-const 
+const
   SET_ELEM_IDX_MASK* = ((1 shl 26) - 1)
   SET_ELEM_FREE_FLAG* = (1 shl (sizeof(cint) * 8 - 1))
 
-# Checks whether the element pointed by ptr belongs to a set or not 
+# Checks whether the element pointed by ptr belongs to a set or not
 
 #************************************ Graph *******************************************
 #
@@ -733,18 +736,18 @@ const
 #         next[1] points to the next edge in the vtx[1] adjacency list.
 #
 
-type 
-  TGraphEdge* {.pure, final.} = object 
+type
+  TGraphEdge* {.pure, final.} = object
     flags*: cint
     weight*: cfloat
     next*: array[0..2 - 1, ptr TGraphEdge]
     vtx*: array[0..2 - 1, ptr TGraphVtx]
 
-  TGraphVtx* {.pure, final.} = object 
+  TGraphVtx* {.pure, final.} = object
     flags*: cint
     first*: ptr TGraphEdge
 
-  TGraphVtx2D* {.pure, final.} = object 
+  TGraphVtx2D* {.pure, final.} = object
     flags*: cint
     first*: ptr TGraphEdge
     thePtr*: ptr TPoint2D32f
@@ -755,56 +758,56 @@ type
 #   and includes another set (edges)
 #
 
-type 
-  TGraph* {.pure, final.} = object 
-    flags*: cint              # Miscellaneous flags.     
-    headerSize*: cint        # Size of sequence header. 
-    vNext*: ptr TSeq         # 2nd next sequence.       
-    total*: cint              # Total number of elements.            
-    elemSize*: cint          # Size of sequence element in bytes.   
-    blockMax*: ptr Schar     # Maximal bound of the last block.     
-    thePtr*: ptr Schar        # Current write pointer.               
-    deltaElems*: cint        # Grow seq this many at a time.        
-    storage*: ptr TMemStorage # Where the seq is stored.             
-    freeBlocks*: ptr TSeqBlock # Free blocks list.                    
-    first*: ptr TSeqBlock     # Pointer to the first sequence block. 
+type
+  TGraph* {.pure, final.} = object
+    flags*: cint              # Miscellaneous flags.
+    headerSize*: cint        # Size of sequence header.
+    vNext*: ptr TSeq         # 2nd next sequence.
+    total*: cint              # Total number of elements.
+    elemSize*: cint          # Size of sequence element in bytes.
+    blockMax*: ptr Schar     # Maximal bound of the last block.
+    thePtr*: ptr Schar        # Current write pointer.
+    deltaElems*: cint        # Grow seq this many at a time.
+    storage*: ptr TMemStorage # Where the seq is stored.
+    freeBlocks*: ptr TSeqBlock # Free blocks list.
+    first*: ptr TSeqBlock     # Pointer to the first sequence block.
     freeElems*: ptr TSetElem
     activeCount*: cint
     edges*: ptr TSet
 
 
-const 
+const
   TYPE_NAME_GRAPH* = "opencv-graph"
 
 #********************************** Chain/Countour ************************************
 
-type 
-  TChain* {.pure, final.} = object 
-    flags*: cint              # Miscellaneous flags.     
-    headerSize*: cint        # Size of sequence header. 
-    vNext*: ptr TSeq         # 2nd next sequence.       
-    total*: cint              # Total number of elements.            
-    elemSize*: cint          # Size of sequence element in bytes.   
-    blockMax*: ptr Schar     # Maximal bound of the last block.     
-    thePtr*: ptr Schar        # Current write pointer.               
-    deltaElems*: cint        # Grow seq this many at a time.        
-    storage*: ptr TMemStorage # Where the seq is stored.             
-    freeBlocks*: ptr TSeqBlock # Free blocks list.                    
-    first*: ptr TSeqBlock     # Pointer to the first sequence block. 
+type
+  TChain* {.pure, final.} = object
+    flags*: cint              # Miscellaneous flags.
+    headerSize*: cint        # Size of sequence header.
+    vNext*: ptr TSeq         # 2nd next sequence.
+    total*: cint              # Total number of elements.
+    elemSize*: cint          # Size of sequence element in bytes.
+    blockMax*: ptr Schar     # Maximal bound of the last block.
+    thePtr*: ptr Schar        # Current write pointer.
+    deltaElems*: cint        # Grow seq this many at a time.
+    storage*: ptr TMemStorage # Where the seq is stored.
+    freeBlocks*: ptr TSeqBlock # Free blocks list.
+    first*: ptr TSeqBlock     # Pointer to the first sequence block.
     origin*: TPoint
 
-  TContour* {.pure, final.} = object 
-    flags*: cint              # Miscellaneous flags.     
-    headerSize*: cint        # Size of sequence header. 
-    vNext*: ptr TSeq         # 2nd next sequence.       
-    total*: cint              # Total number of elements.            
-    elemSize*: cint          # Size of sequence element in bytes.   
-    blockMax*: ptr Schar     # Maximal bound of the last block.     
-    thePtr*: ptr Schar        # Current write pointer.               
-    deltaElems*: cint        # Grow seq this many at a time.        
-    storage*: ptr TMemStorage # Where the seq is stored.             
-    freeBlocks*: ptr TSeqBlock # Free blocks list.                    
-    first*: ptr TSeqBlock     # Pointer to the first sequence block. 
+  TContour* {.pure, final.} = object
+    flags*: cint              # Miscellaneous flags.
+    headerSize*: cint        # Size of sequence header.
+    vNext*: ptr TSeq         # 2nd next sequence.
+    total*: cint              # Total number of elements.
+    elemSize*: cint          # Size of sequence element in bytes.
+    blockMax*: ptr Schar     # Maximal bound of the last block.
+    thePtr*: ptr Schar        # Current write pointer.
+    deltaElems*: cint        # Grow seq this many at a time.
+    storage*: ptr TMemStorage # Where the seq is stored.
+    freeBlocks*: ptr TSeqBlock # Free blocks list.
+    first*: ptr TSeqBlock     # Pointer to the first sequence block.
     rect*: TRect
     color*: cint
     reserved*: array[0..3 - 1, cint]
@@ -815,61 +818,61 @@ type
 #                                    Sequence types                                      *
 #\***************************************************************************************
 
-const 
+const
   SEQ_MAGIC_VAL* = 0x42990000
 
-const 
+const
   SET_MAGIC_VAL* = 0x42980000
 
-const 
+const
   SEQ_ELTYPE_BITS* = 12
   SEQ_ELTYPE_MASK* = ((1 shl SEQ_ELTYPE_BITS) - 1)
-  SEQ_ELTYPE_POINT* = CV_32SC2 # (x,y) 
-  SEQ_ELTYPE_CODE* = CV_8UC1  # freeman code: 0..7 
+  SEQ_ELTYPE_POINT* = CV_32SC2 # (x,y)
+  SEQ_ELTYPE_CODE* = CV_8UC1  # freeman code: 0..7
   SEQ_ELTYPE_GENERIC* = 0
   SEQ_ELTYPE_PTR* = USRTYPE1
-  SEQ_ELTYPE_PPOINT* = SEQ_ELTYPE_PTR # &(x,y) 
-  SEQ_ELTYPE_INDEX* = CV_32SC1 # #(x,y) 
-  SEQ_ELTYPE_GRAPH_EDGE* = 0  # &next_o, &next_d, &vtx_o, &vtx_d 
-  SEQ_ELTYPE_GRAPH_VERTEX* = 0 # first_edge, &(x,y) 
-  SEQ_ELTYPE_TRIAN_ATR* = 0   # vertex of the binary tree   
-  SEQ_ELTYPE_CONNECTED_COMP* = 0 # connected component  
-  SEQ_ELTYPE_POINT3D* = CV_32FC3 # (x,y,z)  
+  SEQ_ELTYPE_PPOINT* = SEQ_ELTYPE_PTR # &(x,y)
+  SEQ_ELTYPE_INDEX* = CV_32SC1 # #(x,y)
+  SEQ_ELTYPE_GRAPH_EDGE* = 0  # &next_o, &next_d, &vtx_o, &vtx_d
+  SEQ_ELTYPE_GRAPH_VERTEX* = 0 # first_edge, &(x,y)
+  SEQ_ELTYPE_TRIAN_ATR* = 0   # vertex of the binary tree
+  SEQ_ELTYPE_CONNECTED_COMP* = 0 # connected component
+  SEQ_ELTYPE_POINT3D* = CV_32FC3 # (x,y,z)
   SEQ_KIND_BITS* = 2
   SEQ_KIND_MASK* = (((1 shl SEQ_KIND_BITS) - 1) shl SEQ_ELTYPE_BITS)
 
-# types of sequences 
+# types of sequences
 
-const 
+const
   SEQ_KIND_GENERIC* = (0 shl SEQ_ELTYPE_BITS)
   SEQ_KIND_CURVE* = (1 shl SEQ_ELTYPE_BITS)
   SEQ_KIND_BIN_TREE* = (2 shl SEQ_ELTYPE_BITS)
 
-# types of sparse sequences (sets) 
+# types of sparse sequences (sets)
 
-const 
+const
   SEQ_KIND_GRAPH* = (1 shl SEQ_ELTYPE_BITS)
   SEQ_KIND_SUBDIV2D* = (2 shl SEQ_ELTYPE_BITS)
   SEQ_FLAG_SHIFT* = (SEQ_KIND_BITS + SEQ_ELTYPE_BITS)
 
-# flags for curves 
+# flags for curves
 
-const 
+const
   SEQ_FLAG_CLOSED* = (1 shl SEQ_FLAG_SHIFT)
   SEQ_FLAG_SIMPLE* = (0 shl SEQ_FLAG_SHIFT)
   SEQ_FLAG_CONVEX* = (0 shl SEQ_FLAG_SHIFT)
   SEQ_FLAG_HOLE* = (2 shl SEQ_FLAG_SHIFT)
 
-# flags for graphs 
+# flags for graphs
 
-const 
+const
   GRAPH_FLAG_ORIENTED* = (1 shl SEQ_FLAG_SHIFT)
   GRAPH* = SEQ_KIND_GRAPH
   ORIENTED_GRAPH* = (SEQ_KIND_GRAPH or GRAPH_FLAG_ORIENTED)
 
-# point sets 
+# point sets
 
-const 
+const
   SEQ_POINT_SET* = (SEQ_KIND_GENERIC or SEQ_ELTYPE_POINT)
   SEQ_POINT3D_SET* = (SEQ_KIND_GENERIC or SEQ_ELTYPE_POINT3D)
   SEQ_POLYLINE* = (SEQ_KIND_CURVE or SEQ_ELTYPE_POINT)
@@ -877,65 +880,65 @@ const
   SEQ_CONTOUR* = SEQ_POLYGON
   SEQ_SIMPLE_POLYGON* = (SEQ_FLAG_SIMPLE or SEQ_POLYGON)
 
-# chain-coded curves 
+# chain-coded curves
 
-const 
+const
   SEQ_CHAIN* = (SEQ_KIND_CURVE or SEQ_ELTYPE_CODE)
   SEQ_CHAIN_CONTOUR* = (SEQ_FLAG_CLOSED or SEQ_CHAIN)
 
-# binary tree for the contour 
+# binary tree for the contour
 
-const 
+const
   SEQ_POLYGON_TREE* = (SEQ_KIND_BIN_TREE or SEQ_ELTYPE_TRIAN_ATR)
 
-# sequence of the connected components 
+# sequence of the connected components
 
-const 
+const
   SEQ_CONNECTED_COMP* = (SEQ_KIND_GENERIC or SEQ_ELTYPE_CONNECTED_COMP)
 
-# sequence of the integer numbers 
+# sequence of the integer numbers
 
-const 
+const
   SEQ_INDEX* = (SEQ_KIND_GENERIC or SEQ_ELTYPE_INDEX)
 
-# flag checking 
+# flag checking
 
 #**************************************************************************************
-#                            Sequence writer & reader                                  
+#                            Sequence writer & reader
 #**************************************************************************************
 
-type 
-  TSeqWriter* {.pure, final.} = object 
+type
+  TSeqWriter* {.pure, final.} = object
     headerSize*: cint
-    seq*: ptr TSeq            # the sequence written 
-    theBlock*: ptr TSeqBlock     # current block 
-    thePtr*: ptr Schar        # pointer to free space 
+    seq*: ptr TSeq            # the sequence written
+    theBlock*: ptr TSeqBlock     # current block
+    thePtr*: ptr Schar        # pointer to free space
     blockMin*: ptr Schar     # pointer to the beginning of block
-    blockMax*: ptr Schar     # pointer to the end of block 
-  
-  TSeqReader* {.pure, final.} = object 
+    blockMax*: ptr Schar     # pointer to the end of block
+
+  TSeqReader* {.pure, final.} = object
     headerSize*: cint
-    seq*: ptr TSeq            # sequence, beign read 
-    theBlock*: ptr TSeqBlock     # current block 
-    thePtr*: ptr Schar        # pointer to element be read next 
-    blockMin*: ptr Schar     # pointer to the beginning of block 
-    blockMax*: ptr Schar     # pointer to the end of block 
-    deltaIndex*: cint        # = seq->first->start_index   
-    prevElem*: ptr Schar     # pointer to previous element 
-  
+    seq*: ptr TSeq            # sequence, beign read
+    theBlock*: ptr TSeqBlock     # current block
+    thePtr*: ptr Schar        # pointer to element be read next
+    blockMin*: ptr Schar     # pointer to the beginning of block
+    blockMax*: ptr Schar     # pointer to the end of block
+    deltaIndex*: cint        # = seq->first->start_index
+    prevElem*: ptr Schar     # pointer to previous element
+
 
 #**************************************************************************************
-#                                Operations on sequences                               
+#                                Operations on sequences
 #**************************************************************************************
 #***************************************************************************************\
 #             Data structures for persistence (a.k.a serialization) functionality        *
 #\***************************************************************************************
-# "black box" file storage 
+# "black box" file storage
 
 
-# Storage flags: 
+# Storage flags:
 
-const 
+const
   STORAGE_READ* = 0
   STORAGE_WRITE* = 1
   STORAGE_WRITE_TEXT* = STORAGE_WRITE
@@ -947,26 +950,26 @@ const
   STORAGE_FORMAT_XML* = 8
   STORAGE_FORMAT_YAML* = 16
 
-# List of attributes: 
+# List of attributes:
 
-type 
-  TAttrList* {.pure, final.} = object 
-    attr*: cstringArray       # NULL-terminated array of (attribute_name,attribute_value) pairs. 
-    next*: ptr TAttrList      # Pointer to next chunk of the attributes list.                    
-  
+type
+  TAttrList* {.pure, final.} = object
+    attr*: cstringArray       # NULL-terminated array of (attribute_name,attribute_value) pairs.
+    next*: ptr TAttrList      # Pointer to next chunk of the attributes list.
+
 
 proc attrList*(attr: cstringArray = nil; next: ptr TAttrList = nil): TAttrList {.
-    cdecl.} = 
+    cdecl.} =
   var l: TAttrList
   l.attr = attr
   l.next = next
   return l
 
-type 
-  TTypeInfo* {.pure, final.} = object 
-  
+type
+  TTypeInfo* {.pure, final.} = object
 
-const 
+
+const
   NODE_NONE* = 0
   NODE_INT* = 1
   NODE_INTEGER* = NODE_INT
@@ -974,66 +977,66 @@ const
   NODE_FLOAT* = NODE_REAL
   NODE_STR* = 3
   NODE_STRING* = NODE_STR
-  NODE_REF* = 4               # not used 
+  NODE_REF* = 4               # not used
   NODE_SEQ* = 5
   NODE_MAP* = 6
   NODE_TYPE_MASK* = 7
 
-template Node_Type*(flags: expr): expr = 
+template Node_Type*(flags: untyped): untyped =
   ((flags) and NODE_TYPE_MASK)
 
-# file node flags 
+# file node flags
 
-const 
-  NODE_FLOW* = 8              # Used only for writing structures in YAML format. 
+const
+  NODE_FLOW* = 8              # Used only for writing structures in YAML format.
   NODE_USER* = 16
   NODE_EMPTY* = 32
   NODE_NAMED* = 64
 
-template Node_Is_Int*(flags: expr): expr = 
+template Node_Is_Int*(flags: untyped): untyped =
   (NODE_TYPE(flags) == NODE_INT)
 
-template Node_Is_Real*(flags: expr): expr = 
+template Node_Is_Real*(flags: untyped): untyped =
   (NODE_TYPE(flags) == NODE_REAL)
 
-template Node_Is_String*(flags: expr): expr = 
+template Node_Is_String*(flags: untyped): untyped =
   (NODE_TYPE(flags) == NODE_STRING)
 
-template Node_Is_Seq*(flags: expr): expr = 
+template Node_Is_Seq*(flags: untyped): untyped =
   (NODE_TYPE(flags) == NODE_SEQ)
 
-template Node_Is_Map*(flags: expr): expr = 
+template Node_Is_Map*(flags: untyped): untyped =
   (NODE_TYPE(flags) == NODE_MAP)
 
-template Node_Is_Collection*(flags: expr): expr = 
+template Node_Is_Collection*(flags: untyped): untyped =
   (NODE_TYPE(flags) >= NODE_SEQ)
 
-template Node_Is_Flow*(flags: expr): expr = 
+template Node_Is_Flow*(flags: untyped): untyped =
   (((flags) and NODE_FLOW) != 0)
 
-template Node_Is_Empty*(flags: expr): expr = 
+template Node_Is_Empty*(flags: untyped): untyped =
   (((flags) and NODE_EMPTY) != 0)
 
-template Node_Is_User*(flags: expr): expr = 
+template Node_Is_User*(flags: untyped): untyped =
   (((flags) and NODE_USER) != 0)
 
-template Node_Has_Name*(flags: expr): expr = 
+template Node_Has_Name*(flags: untyped): untyped =
   (((flags) and NODE_NAMED) != 0)
 
-const 
+const
   NODE_SEQ_SIMPLE* = 256
 
-type 
-  TString* {.pure, final.} = object 
+type
+  TString* {.pure, final.} = object
     len*: cint
     thePtr*: cstring
 
 
 # All the keys (names) of elements in the readed file storage
-#   are stored in the hash to speed up the lookup operations: 
+#   are stored in the hash to speed up the lookup operations:
 
-type 
-  TStringHashNode* {.pure, final.} = object 
+type
+  TStringHashNode* {.pure, final.} = object
     hashval*: cuint
     str*: TString
     next*: ptr TStringHashNode
@@ -1041,33 +1044,33 @@ type
   TGenericHash {.pure, final.} = object
 
   TFileNodeHash* = TGenericHash
-  TFileNodeData* {.pure, final.} = object 
-    f*: cdouble               # scalar floating-point number 
-    i*: cint                  # scalar integer number 
-    str*: TString             # text string 
-    seq*: TSeq                # sequence (ordered collection of file nodes) 
-    map*: TFileNodeHash       # map (collection of named file nodes) 
-  
+  TFileNodeData* {.pure, final.} = object
+    f*: cdouble               # scalar floating-point number
+    i*: cint                  # scalar integer number
+    str*: TString             # text string
+    seq*: TSeq                # sequence (ordered collection of file nodes)
+    map*: TFileNodeHash       # map (collection of named file nodes)
+
 
 #var fileNodeData*: TFileNodeData
 
-# Basic element of the file storage - scalar or collection: 
+# Basic element of the file storage - scalar or collection:
 
-type 
-  TFileNode* {.pure, final.} = object 
+type
+  TFileNode* {.pure, final.} = object
     tag*: cint
     info*: ptr TTypeInfo      # type information
-                              #            (only for user-defined object, for others it is 0) 
+                              #            (only for user-defined object, for others it is 0)
     data*: TFileNodeData
   TFileStorage* {.pure, final.} = object
   TIsInstanceFunc* = proc (structPtr: pointer): cint {.cdecl.}
   TReleaseFunc* = proc (structDblptr: ptr pointer) {.cdecl.}
   TReadFunc* = proc (storage: ptr TFileStorage; node: ptr TFileNode): pointer {.
       cdecl.}
-  TWriteFunc* = proc (storage: ptr TFileStorage; name: cstring; 
+  TWriteFunc* = proc (storage: ptr TFileStorage; name: cstring;
                       structPtr: pointer; attributes: TAttrList) {.cdecl.}
   TCloneFunc* = proc (structPtr: pointer): pointer {.cdecl.}
-  TCvTypeInfo* {.pure, final.} = object 
+  TCvTypeInfo* {.pure, final.} = object
     flags*: cint
     headerSize*: cint
     prev*: ptr TTypeInfo
@@ -1082,19 +1085,19 @@ type
 
 #*** System data types *****
 
-type 
-  TPluginFuncInfo* {.pure, final.} = object 
+type
+  TPluginFuncInfo* {.pure, final.} = object
     funcAddr*: ptr pointer
     defaultFuncAddr*: pointer
     funcNames*: cstring
     searchModules*: cint
     loadedFrom*: cint
 
-  TModuleInfo* {.pure, final.} = object 
+  TModuleInfo* {.pure, final.} = object
     next*: ptr TModuleInfo
     name*: cstring
     version*: cstring
     funcTab*: ptr TPluginFuncInfo
 
 
-# End of file. 
+# End of file.


### PR DESCRIPTION
`ptr TArr` changed to `ImgPtr`
`ptr TMat` now `MatPtr`, `ptr TMatND` now `MatNDPtr`
Remove trailing blanks
`expr` changed to `untyped` (remove heaps of compiler warnings)
Allow non-debug and non-versioned dlls on windows. (Issue #3)

@dom96,  This is in preparation for adding procs that return the "dst" image (similar to Python syntax),
but firstly, are you happy with ImgPtr (since these TArr arrays/matrices are images)?